### PR TITLE
Not only checks composer.phar is present, downloads it and run install

### DIFF
--- a/php/providers/composer.rb
+++ b/php/providers/composer.rb
@@ -4,30 +4,23 @@ end
 
 action :install do
   deploy_to = new_resource.name
+  
   if !::File.directory?(deploy_to)
     raise "#{deploy_to} is not a directory"
   end
+  
   if !::File.exists?("#{deploy_to}/composer.phar")
-    Chef::Log.info("Could not find 'composer.phar' in #{deploy_to}: silently skipping.")
-  else
-    script "install dependencies with composer" do
-      interpreter "bash"
-      cwd         deploy_to
-      user        "www-data"
-      code <<-EOH
-      PATH=$PATH:/usr/bin:/usr/local/bin
-      export PATH
-
-      PHP_CMD=$(which php)
-
-      HAS_PHAR=$(php -m|grep Phar|wc -l)
-      if [ $HAS_PHAR -eq 0 ]; then
-        echo "No phar installed."
-        exit 1        
-      fi
-      COMPOSER="${PHP_CMD} composer.phar --quiet --no-interaction install"
-      $($COMPOSER)
-      EOH
+    remote_file "#{deploy_to}/composer.phar" do
+      source "http://getcomposer.org/composer.phar"
+      mode "0774"
+    end
+  end
+  
+  if !::File.exists?("#{deploy_to}/composer.lock")
+    execute "install dependencies with composer" do
+      cwd deploy_to
+      user "root"
+      command "php composer.phar install"
     end
   end
 end


### PR DESCRIPTION
Previously if composer.phar wasn't available the install
process would be halted. Now, provider checks if composer.phar
is available and downloads it, if it's not. It also checks
for composer.lock instead to decide to run the install or not
