### PR TITLE
added fruitkid env to allowed ssl cluster

### DIFF
--- a/nginx-lb/attributes/default.rb
+++ b/nginx-lb/attributes/default.rb
@@ -1,4 +1,4 @@
 default["nginx-lb"]["role"]    = "lb"
-default["nginx-lb"]["cluster"] = ["EasyBib Playground", "EasyBib"]
+default["nginx-lb"]["cluster"] = ["Fruitkid", "EasyBib Playground", "EasyBib"]
 default["nginx-lb"]["dir"]     = "/etc/nginx"
 default["nginx-lb"]["int_ip"]  = "127.0.0.1"


### PR DESCRIPTION
This is required to deploy an ssl app to fruitkid's lb.
