### PR TITLE
Add basic avahi setup/configuration recipe

### DIFF
--- a/avahi/metadata.rb
+++ b/avahi/metadata.rb
@@ -1,0 +1,8 @@
+maintainer        "Leander Damme, Till Klampaeckel"
+maintainer_email  "leander@wesrc.com"
+license           "BSD License"
+description       "Installs and configures avahi daemon"
+version           "0.1"
+recipe            "avahi::default", "Installs avahi"
+
+supports 'ubuntu'

--- a/avahi/recipes/default.rb
+++ b/avahi/recipes/default.rb
@@ -1,0 +1,14 @@
+# installs avahi-daemon
+package "avahi-daemon"
+
+template "/etc/avahi/avahi-daemon.conf" do
+  source "avahi-daemon.conf.erb"
+  mode   "0644"
+  owner  "root"
+  group  "root"
+end
+
+service "avahi-daemon" do
+  supports :status => true, :restart => true, :reload => false
+  action [ :restart ]
+end

--- a/avahi/templates/default/avahi-daemon.conf.erb
+++ b/avahi/templates/default/avahi-daemon.conf.erb
@@ -1,0 +1,64 @@
+# $Id$
+#
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+# See avahi-daemon.conf(5) for more information on this configuration
+# file!
+
+[server]
+#host-name=foo
+#domain-name=local
+#browse-domains=0pointer.de, zeroconf.org
+use-ipv4=yes
+use-ipv6=no
+allow-interfaces=eth1
+#deny-interfaces=eth1
+#check-response-ttl=no
+#use-iff-running=no
+enable-dbus=yes
+#disallow-other-stacks=no
+#allow-point-to-point=no
+
+[wide-area]
+enable-wide-area=yes
+
+[publish]
+#disable-publishing=no
+#disable-user-service-publishing=no
+#add-service-cookie=no
+publish-addresses=yes
+publish-hinfo=yes
+#publish-workstation=yes
+publish-domain=yes
+#publish-dns-servers=192.168.50.1, 192.168.50.2
+#publish-resolv-conf-dns-servers=yes
+#publish-aaaa-on-ipv4=yes
+#publish-a-on-ipv6=no
+
+[reflector]
+#enable-reflector=no
+#reflect-ipv=no
+
+[rlimits]
+#rlimit-as=
+rlimit-core=0
+rlimit-data=4194304
+rlimit-fsize=0
+rlimit-nofile=300
+rlimit-stack=4194304
+rlimit-nproc=3

--- a/avahi/templates/default/web.service.erb
+++ b/avahi/templates/default/web.service.erb
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+    <name replace-wildcards="yes"> <%= @description %> <%= @cname %> (%h)</name>
+    <service>
+        <type>_http._tcp</type>
+        <subtype>_cname._http._tcp</subtype>
+        <domain-name><%= @cname %>.local</domain-name>
+        <host-name>vagrant.local</host-name>
+        <port><%= @port %></port>
+    </service>
+</service-group>


### PR DESCRIPTION
This recipe installs avahi so the Host operating system can resolve the IP of the VM
The hostname of the VM should be set via the Vagrantfile `config.vm.hostname = "management"`
management.local should then resolve to the `web_config.vm.network :private_network, ip: "33.33.33.145"` configured on eth1
