### PR TITLE
Fixing the Chef-Workaround

### DIFF
--- a/bibcd/providers/app.rb
+++ b/bibcd/providers/app.rb
@@ -7,9 +7,9 @@ action :add do
     template "#{new_resource.path}/config/apps/#{new_resource.app_name}.yml" do
       cookbook "bibcd" #if we dont set this, the template cmd would search in the calling cookbook
       mode   0644
-      #This is an ugly quick hack: Ruby Yaml adds !map:Mash which the Symfony Yaml parser doesnt like. So lets remove it.
-      #maybe file an issue with symfony yaml late 
-      variables :content => YAML::dump(new_resource.config.to_hash).gsub('!map:Mash','')
+      #This is an ugly quick hack: Ruby Yaml adds !map:Chef::Node::ImmutableMash which the Symfony Yaml 
+      #parser doesnt like. So lets remove it.
+      variables :content => YAML::dump(new_resource.config.to_hash).gsub('!map:Chef::Node::ImmutableMash','')
       source "app.yml.erb"
     end
     


### PR DESCRIPTION
The workaround for the yaml generation from chef to symfony apparently needs to be changed to work with chef11.
