### PR TITLE
Enhancement: Prosody: Using reload instead of restart

### DIFF
--- a/prosody/recipes/configure.rb
+++ b/prosody/recipes/configure.rb
@@ -32,7 +32,7 @@ template "#{cfg_dir}/prosody.cfg.lua" do
   variables(
     :include_files => "#{cfg_partial_dir}/*.cfg.lua"
   )
-  notifies :restart, "service[prosody]"
+  notifies :reload, "service[prosody]"
 end
 
 template "#{cfg_partial_dir}/prosody.cfg.lua" do
@@ -45,7 +45,7 @@ template "#{cfg_partial_dir}/prosody.cfg.lua" do
     :db => node["prosody"]["db"],
     :domains => node["prosody"]["domains"]
   )
-  notifies :restart, "service[prosody]"
+  notifies :reload, "service[prosody]"
 end
 
 include_recipe "prosody::ssl"

--- a/prosody/recipes/groups.rb
+++ b/prosody/recipes/groups.rb
@@ -11,9 +11,9 @@ template "/var/prosody/sharedgroups.txt" do
   source "sharedgroups.txt.erb"
   owner "prosody"
   group "prosody"
-  mode "0644"
+  mode "0600"
   variables({
     :groups => node['prosody']['groups'],
   })
-  notifies :restart, "service[prosody]"
+  notifies :reload, "service[prosody]"
 end

--- a/prosody/recipes/service.rb
+++ b/prosody/recipes/service.rb
@@ -1,4 +1,5 @@
 service "prosody" do
   action :nothing
   supports [ :start, :stop, :restart, :reload ]
+  reload_command "/usr/bin/prosodyctl reload"
 end


### PR DESCRIPTION
Deployments dont interrupt Prosody anymore
