### PR TITLE
fixing nonworking prosody groups

### DIFF
--- a/prosody/recipes/groups.rb
+++ b/prosody/recipes/groups.rb
@@ -1,4 +1,4 @@
-groups_cfg = "/etc/prosody/conf.d/prosody_groups.lua"
+groups_cfg = "/etc/prosody/conf.d/prosody_groups.cfg.lua"
 
 execute "load sharedgroups" do
   command "echo 'groups_file = \"/var/prosody/sharedgroups.txt\"' >> #{groups_cfg}"


### PR DESCRIPTION
Prosody checks only for *.cfg.lua, the extension was wrong. Fixes #75 
