### PR TITLE
Debug-Feature: Adding a verbose debug format

### DIFF
--- a/rsyslogd/files/default/debug-helper.conf
+++ b/rsyslogd/files/default/debug-helper.conf
@@ -1,0 +1,1 @@
+$template DebugSyslogFormat, "<%pri%> [%pri-text%] [%syslogtag%] %protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% %msg%\n"

--- a/rsyslogd/recipes/default.rb
+++ b/rsyslogd/recipes/default.rb
@@ -3,3 +3,7 @@ service "rsyslog" do
   action [ :nothing ]
 end
 
+cookbook_file "/etc/rsyslog.d/10-debug-helper.conf" do
+  source "debug-helper.conf"
+  mode 0644
+end


### PR DESCRIPTION
When debugging rsyslogd message routing, I would like to have a predefined message format which shows pri-text and syslogtag I can enabled while debugging.

It is not used by default, therefore should not have any impact on production.
