### PR TITLE
Adding composer-setup to gearman worker

### DIFF
--- a/easybib/recipes/role-gearmanw.rb
+++ b/easybib/recipes/role-gearmanw.rb
@@ -7,6 +7,7 @@ include_recipe "unfuddle-ssl-fix::install"
 include_recipe "php-gearman"
 include_recipe "php-phar"
 include_recipe "php-posix"
+include_recipe "composer::configure"
 include_recipe "deploy::easybib"
 
 if is_aws()


### PR DESCRIPTION
Deployment might fail otherwise, since `/var/www/.composer` does not exist and is not writeable
