### PR TITLE
Fix: upgrade pip only if we're not upgraded

### DIFF
--- a/avahi/recipes/alias.rb
+++ b/avahi/recipes/alias.rb
@@ -7,7 +7,10 @@ end
 execute "update pip" do
   command "pip install --upgrade pip"
   only_if do
-    `pip -V`.split(' ')[1] != '1.5'
+    cmd = Mixlib::ShellOut.new("pip -V")
+    cmd.run_command
+    pip_version = cmd.stdout
+    pip_version.split(' ')[1] != '1.5'
   end
 end
 


### PR DESCRIPTION
Related: easybib/issues#508

Problem: If you ran provision on a box which was already running,
the pip upgrade failed because of setuptools and a missing option
switch.
