### PR TITLE
Using allow_deploy in easybib-recipe

### DIFF
--- a/deploy/recipes/easybib.rb
+++ b/deploy/recipes/easybib.rb
@@ -9,18 +9,17 @@ node["deploy"].each do |application, deploy|
 
   case application
   when 'easybib'
-    if !['EasyBib', 'EasyBib Playground', 'Fruitkid', 'Fruitkid Playground'].include?(cluster_name)
-      next
-    end
-    if !instance_roles.include?('nginxphpapp') && !instance_roles.include?('testapp')
+    nginxphpapp_allowed = allow_deploy(application,'easybib','nginxphpapp')
+    testapp_allowed     = allow_deploy(application,'easybib','testapp')
+    if !nginxphpapp_allowed && !testapp_allowed
       next
     end
 
   when 'easybib_api'
-    next unless instance_roles.include?('bibapi')
+    next unless allow_deploy(application,'easybib_api','bibapi')
 
   when 'gearmanworker'
-    next unless instance_roles.include?('gearman-worker')
+    next unless allow_deploy(application,'gearmanworker','gearman-worker')
 
   else
     Chef::Log.info("deploy::easybib - #{application} (in #{cluster_name}) skipped")


### PR DESCRIPTION
I need to remove the static cluster name check in the recipe to have easybib deployed on Easybib Loadtest. The cluster name check is still being done in the easybib-library in allow_deploy. This change fixes by accident easybib/issues#107, too :)

@till I am not sure about the "testapp" check. I just migrated it from the old recipe, but since we currently do not have any testapp application in the config, I guess this is some old leftover, so we could simplify here even further.

fixes easybib/issues#107
