### PR TITLE
Only deploy bibcd and bibopsstatus in qa

### DIFF
--- a/deploy/recipes/qa.rb
+++ b/deploy/recipes/qa.rb
@@ -3,12 +3,14 @@ include_recipe "nginx-app::service"
 
 node['deploy'].each do |application, deploy|
 
-  if application == 'bibcd'
+  case application
+  when 'bibcd'
     next unless allow_deploy(application, 'bibcd')
-  end
-
-  if application == 'bib-opsstatus'
+  when 'bib-opsstatus'
     next unless allow_deploy(application, 'bib-opsstatus')
+  else
+    Chef::Log.info("deploy::qa - #{application} skipped")
+    next
   end
 
   Chef::Log.info("deploy::#{application} - Deployment started.")


### PR DESCRIPTION
Reprovisioning of the QA-Instance took way longer than I anticipated. Debugging this revealed that we are checking out satis on the machine too, since it is part of the stacks application, and therefore just "skips" the two ifs.

This commit makes sure that all unknown applications are skipped.
