### PR TITLE
Fix for suddenly appeared chef error

### DIFF
--- a/easybib/recipes/setup.rb
+++ b/easybib/recipes/setup.rb
@@ -10,7 +10,9 @@ base_packages.each do |p|
   package p
 end
 
-chef_gem "BibOpsworks"
+chef_gem "BibOpsworks" do
+  action :install
+end
 
 service "nscd" do
   action :nothing


### PR DESCRIPTION
Probably due to some Chef-Environment Setup, `chef_gem "BibOpsworks"` suddenly fails. This PR fixes it.

`[2014-01-30T10:03:40+00:00] FATAL: ArgumentError: ruby_block[Compile Custom OpsWorks Run List] (opsworks_custom_cookbooks::execute line 3) had an error: ArgumentError: chef_gem[BibOpsworks] (easybib::setup line 13) had an error: ArgumentError: Illformed requirement [""]`

Related (aka it could be everything): https://tickets.opscode.com/browse/CHEF-3912
