### PR TITLE
We check for license.empty?, so default should be empty

### DIFF
--- a/newrelic/attributes/default.rb
+++ b/newrelic/attributes/default.rb
@@ -1,5 +1,5 @@
 default["newrelic"] = {}
-default["newrelic"]["license"] = "change me"
+default["newrelic"]["license"] = ""
 
 default["newrelic"]["sysmond"] = {}
 default["newrelic"]["sysmond"]["log"] = {}


### PR DESCRIPTION
fixes easybib/issues#661
