### PR TITLE
Added check if application exists in stack json

### DIFF
--- a/deploy/recipes/internal-api.rb
+++ b/deploy/recipes/internal-api.rb
@@ -44,13 +44,27 @@ node['deploy'].each do |application, deploy|
     app application
   end
 
+  routes_enabled = []
+  routes_disabled = []
+
+  if node["nginx-app"].attribute?(application)
+    if node["nginx-app"][application].attribute?("routes_enabled")
+      routes_enabled = node["nginx-app"][application]["routes_enabled"]
+    end
+    if node["nginx-app"][application].attribute?("routes_disabled")
+      routes_disabled = node["nginx-app"][application]["routes_disabled"]
+    end
+  else
+    Chef::Log.warn("No Route Config for #{application} found in Stack JSON, not enabling any routes")
+  end
+
   easybib_nginx application do
     config_template "internal-api.conf.erb"
     domain_name deploy['domains'].join(' ')
     doc_root deploy['document_root']
     access_log      "off"
-    routes_enabled  node["nginx-app"][application]["routes_enabled"]
-    routes_denied   node["nginx-app"][application]["routes_denied"]
+    routes_enabled  routes_enabled
+    routes_denied   routes_disabled
     notifies :restart, "service[nginx]", :delayed
   end
 


### PR DESCRIPTION
Make sure instance provisioning does not fail because an app has been forgotten in stack json - especially since the resulting error message was kind of unusuable.
