### PR TITLE
Satis directory fixes

### DIFF
--- a/deploy/recipes/satis.rb
+++ b/deploy/recipes/satis.rb
@@ -39,7 +39,7 @@ node['deploy'].each do |application, deploy|
     action :create
   end
 
-  %w{"/mnt/satis-output/" "/mnt/composer-tmp/"}.each do |dir|
+  %w{/mnt/satis-output/ /mnt/composer-tmp/}.each do |dir|
     directory dir do
       recursive true
       owner "www-data"


### PR DESCRIPTION
- s3-syncer no longer used
- create ebs directory for satis
- fixed broken directory creation for composer-tmp and satis-output

I am not that happy with the hardcoded path of the ebs directory - but since it is hardcoded in the apps cronjob.sh as well, we should first determine how to make it configurable in both locations.
