### PR TITLE
Bugfix: Current percona version does not want to start

### DIFF
--- a/percona/files/default/my.cnf
+++ b/percona/files/default/my.cnf
@@ -39,7 +39,6 @@ port		= 3306
 basedir		= /usr
 datadir		= /var/lib/mysql
 tmpdir		= /tmp
-lc-messages-dir	= /usr/share/mysql
 skip-external-locking
 #
 # Instead of skip-networking the default is now to listen only on


### PR DESCRIPTION
Current percona versions have another lc-messages-dir, lets use default
