### PR TITLE
Use an ereregex to correctly match pam_unix cron lines

### DIFF
--- a/rsyslogd/files/default/10-mute.conf
+++ b/rsyslogd/files/default/10-mute.conf
@@ -1,3 +1,3 @@
 :msg, startswith, " (root) CMD (/etc/ganglia/scripts/" ~
 :msg, isequal, " (root) CMD ()" ~
-:msg, regex, " pam_unix(cron:session): session (closed|opened) for user root" ~
+:msg, ereregex, " pam_unix\(cron:session\): session (closed|opened) for user root" ~


### PR DESCRIPTION
http://www.rsyslog.com/doc/rsyslog_conf_filter.html
http://www.regular-expressions.info/posix.html
