### PR TITLE
Bugfix: Removing pointless fastcgi_index parameter

### DIFF
--- a/nginx-app/templates/default/partials/php-routes-default.erb
+++ b/nginx-app/templates/default/partials/php-routes-default.erb
@@ -19,7 +19,6 @@
     }
 
     location ~* \.php$ {
-        fastcgi_index index.php;
         fastcgi_pass  <%=@upstream%>_phpfpm;
         include       fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/nginx-app/templates/default/partials/php-routes-specific-routes.erb
+++ b/nginx-app/templates/default/partials/php-routes-specific-routes.erb
@@ -16,7 +16,6 @@ location ~ /(<%= @routes_enabled.join('|') %>) {
         }
 
         location ~* \.php$ {
-            fastcgi_index <%=@default_router%>;
             fastcgi_pass  <%=@upstream%>_phpfpm;
             include       fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
@@ -34,7 +33,6 @@ location ~ /(<%= @routes_enabled.join('|') %>) {
             fastcgi_pass  <%=@upstream%>_phpfpm;
             include       fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root/<%=@default_router%>;
-            fastcgi_index <%=@default_router%>;
 <% if @env_conf && !@env_conf.empty? -%>
             <%=@env_conf%>
 <% end -%>


### PR DESCRIPTION
fastcgi_index applies only if url ends with /, so it is useless for `\.php$` anyway. 

For /, we already supply SCRIPT_FILENAME, so it gets messy if we supply both - and breaks the APIs, since fastcgi_index would be appended to all calls ending with /

http://wiki.nginx.org/HttpFastcgiModule#fastcgi_index

fixes easybib/issues#1180
