### PR TITLE
Removed old satis setup parts

### DIFF
--- a/deploy/recipes/satis.rb
+++ b/deploy/recipes/satis.rb
@@ -31,14 +31,6 @@ node['deploy'].each do |application, deploy|
     app application
   end
 
-  directory '/vol/satis-sync/files/' do
-    recursive true
-    owner "www-data"
-    group "www-data"
-    mode  0755
-    action :create
-  end
-
   %w{/mnt/satis-output/ /mnt/composer-tmp/}.each do |dir|
     directory dir do
       recursive true
@@ -46,24 +38,6 @@ node['deploy'].each do |application, deploy|
       group "www-data"
       mode  0755
       action :create
-    end
-  end
-
-  cron "satis run update-dist.sh in cron - #{application}" do
-    minute "*/30"
-    command "cd #{deploy["deploy_to"]}/current/ && sh update-dist.sh"
-    user "www-data"
-    only_if do
-      File.exists?("#{deploy["deploy_to"]}/current/update-dist.sh")
-    end
-  end
-
-  cron "satis run update-and-pull.sh in cron - #{application}" do
-    minute "*/5"
-    command "cd #{deploy["deploy_to"]}/current/ && sh update-and-pull.sh"
-    user "www-data"
-    only_if do
-      File.exists?("#{deploy["deploy_to"]}/current/update-and-pull.sh")
     end
   end
 


### PR DESCRIPTION
references easybib/issues#1168

`/vol/satis-sync/files/` does no longer need to be created in the cookbooks - it is now created in [the cronjob](https://github.com/easybib/satis-s3/blob/master/bin/cronjob.sh#L21). This way, we have only one file where we have to specify the storage path
