### PR TITLE
[WIP] Changing ruby version, test for easybib_crontab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 1.8.7
+  - 2.0.0
 
 script:
   - find . -type f -name "*.rb" -exec ruby -c {} > /dev/null \;


### PR DESCRIPTION
To replicate & fix easybib/issues#1313

1.8.7 is used by chef 11.4, 2.0.0 by chef 11.10
http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-ruby.html
