### PR TITLE
redis: removed codename test

### DIFF
--- a/redis/recipes/default.rb
+++ b/redis/recipes/default.rb
@@ -1,16 +1,10 @@
 include_recipe "apt::ppa"
 
-case node["lsb"]["codename"]
-when "lucid", "maverick", "natty", "oneiric"
-
-  easybib_launchpad node["redis"]["ppa"] do
-    action :discover
-  end
-
-  package "redis-server"
-
-  include_recipe "redis::user"
-  include_recipe "redis::configure"
-else
-  Chef::Log.error("Unsupported platform: #{node["lsb"]["codename"]}")
+easybib_launchpad node["redis"]["ppa"] do
+  action :discover
 end
+
+package "redis-server"
+
+include_recipe "redis::user"
+include_recipe "redis::configure"


### PR DESCRIPTION
Not sure what the point of testing for the release name was - I just want to install it on Precise.
