### PR TITLE
Bugfix: Fixing NR Racecondition

### DIFF
--- a/newrelic/recipes/server-monitor.rb
+++ b/newrelic/recipes/server-monitor.rb
@@ -12,8 +12,8 @@ end
 template "/etc/default/newrelic-sysmond" do
   source "nrsysmond.default.erb"
   owner "root"
-  group "newrelic"
-  mode "0640"
+  group "root"
+  mode "0644"
 end
 
 host_name = "#{node["hostname"]}.#{get_cluster_name.gsub(/\s+/, "-").strip.downcase}"


### PR DESCRIPTION
We are creating the file before NR installation, so on a
new machine, group "newrelic" does not yet exist
