### PR TITLE
Bugfix: Proper config file handling for NR sysmond

### DIFF
--- a/newrelic/recipes/server-monitor.rb
+++ b/newrelic/recipes/server-monitor.rb
@@ -9,6 +9,14 @@ execute "newrelic-license" do
   end
 end
 
+package "newrelic-sysmond" do
+  action :install
+  notifies :run, "execute[newrelic-license]", :immediately
+  not_if do
+    node["newrelic"]["license"].empty?
+  end
+end
+
 template "/etc/default/newrelic-sysmond" do
   source "nrsysmond.default.erb"
   owner "root"
@@ -30,27 +38,7 @@ template "/etc/newrelic/nrsysmond.easybib.cfg" do
     :hostname => host_name
   )
   action :create
-  notifies :start, "service[newrelic-sysmond]", :immediately
-  not_if do
-    node["newrelic"]["license"].empty?
-  end
-end
-
-# easybib/issues#1332
-commands = [
-  "rm -f /etc/newrelic/nrsysmond.cfg",
-  "apt-get install -f -o Dpkg::Options::=--force-confdef  -y newrelic-sysmond"
-]
-
-commands.each do |cmd|
-  execute "Running: #{cmd}" do
-    command cmd
-  end
-end
-
-package "newrelic-sysmond" do
-  action :upgrade
-  notifies :run, "execute[newrelic-license]", :immediately
+  notifies :restart, "service[newrelic-sysmond]", :immediately
   not_if do
     node["newrelic"]["license"].empty?
   end


### PR DESCRIPTION
We do not at all touch the default config file, so we wont have either deleted nor modified
errors. Instead, we just create our own config file and point NR to it using /etc/default
