### PR TITLE
Fix: Dont notify on usual restarts

### DIFF
--- a/monit/templates/default/mailnotify.monit.erb
+++ b/monit/templates/default/mailnotify.monit.erb
@@ -1,5 +1,5 @@
 set mailserver <%= @host %> USERNAME <%= @mailuser %> PASSWORD <%= @mailpass %> using TLSV1
 set mail-format { from: <%= @mailsender %> }
 <% @recipients.each do |recipient_address| -%>
-set alert <%= recipient_address %> but not on { pid ppid }
+set alert <%= recipient_address %> but not on { pid ppid nonexist instance }
 <% end -%>


### PR DESCRIPTION
Do not alert on "monit instance changed" and "does not exists/exists" - this happens regularly and is nothing we should be nagged for
