### PR TITLE
in hhvm-fcgi::default, first install hhvm, then do the rest

### DIFF
--- a/hhvm-fcgi/recipes/default.rb
+++ b/hhvm-fcgi/recipes/default.rb
@@ -1,4 +1,5 @@
-include_recipe "hhvm-fcgi::prepare"
 include_recipe "hhvm-fcgi::configure-hhvm"
+
+include_recipe "hhvm-fcgi::prepare"
 include_recipe "hhvm-fcgi::configure"
 include_recipe "hhvm-fcgi::service"


### PR DESCRIPTION
otherwise our rendered config files are overwritten by the
install (especially /etc/init.d/hhvm)

/cc @cameronprattedwards
