### PR TITLE
Explicitly use Debian Provider for rsyslogd service

### DIFF
--- a/rsyslogd/recipes/default.rb
+++ b/rsyslogd/recipes/default.rb
@@ -1,5 +1,5 @@
 service "rsyslog" do
-  provider Chef::Provider::Service::Debian
+  provider Chef::Provider::Service::Upstart
   supports :status => true, :restart => true, :reload => true
   action [ :nothing ]
 end


### PR DESCRIPTION
Tested with 12.04, too. Now 14.04 boxes provision as well.
