### PR TITLE
Adding ppa support for apt_repository

### DIFF
--- a/apt/attributes/default.rb
+++ b/apt/attributes/default.rb
@@ -3,7 +3,7 @@ default["apt"]["easybib"] = {}
 default["apt"]["easybib"]["ppa"] = "ppa:easybib/php55"
 default["apt"]["easybib"]["ppa-php55"] = "ppa:easybib/php55"
 default["apt"]["upgrade-package"] = nil
-
+default['apt']['launchpad_api_version'] = '1.0'
 default['apt']['cacher-client']['restrict_environment'] = false
 default['apt']['cacher_dir'] = '/var/cache/apt-cacher-ng'
 default['apt']['cacher_interface'] = nil


### PR DESCRIPTION
This PR adds ppa url support to apt_repository.

Example:

```
apt_repository "php55" do
  uri 'ppa:easybib/php55'
  distribution node["lsb"]["codename"]
end
```
