### PR TITLE
Bugfix: Do not add X-Forwarded-For when req comes from https

### DIFF
--- a/haproxy/templates/default/haproxy.cfg.backend.erb
+++ b/haproxy/templates/default/haproxy.cfg.backend.erb
@@ -23,7 +23,7 @@ backend <%= @layername %>_php_app_servers
   balance roundrobin
   option redispatch
   option httpclose
-  option forwardfor
+  option forwardfor except 127.0.0.1
   option httpchk <%= health_check_string %>
   <% @node[:opsworks][:layers][@layername][:instances].each do |name,backend| -%>
   server <%= name %> <%= backend['private_dns_name'] %>:80 weight <%= backend['backends'] || 10 %> maxconn <%= haproxy_maxconn %> rise <%= haproxy_rise %> fall <%= haproxy_fall %> check inter <%= haproxy_check_interval %>


### PR DESCRIPTION
Requests coming from nginx-ssl should not get X-Forwarded-For 127.0.0.1 header
