### PR TITLE
Restart haproxy only if it is down over three cycles

### DIFF
--- a/haproxy/templates/default/haproxy.monit.erb
+++ b/haproxy/templates/default/haproxy.monit.erb
@@ -2,4 +2,4 @@ check process <%= @app_name %>
   with pidfile "<%= @pid_file %>"
   start program = "<%= @init %> start"
   stop program = "<%= @init %> stop"
-  if failed port 80 protocol http then restart
+  if failed port 80 protocol http for 3 cycles then restart


### PR DESCRIPTION
haproxy is down for a very short period when an instance joins, and we dont want to restart then

fixes easybib/issues#2260
