### PR TITLE
Bugfix: Aptly and + in filenames on s3

### DIFF
--- a/aptly/templates/default/aptly.conf.erb
+++ b/aptly/templates/default/aptly.conf.erb
@@ -19,7 +19,8 @@
       "awsAccessKeyID": "",
       "awsSecretAccessKey": "",
       "prefix": "",
-      "acl": "public-read"
+      "acl": "public-read",
+      "plusWorkaround": true
     }
   }
 }


### PR DESCRIPTION
see https://github.com/smira/aptly/issues/98
