### PR TITLE
Bugfix: Do not use su - www-data

### DIFF
--- a/opsworks_nodejs/libraries/nodejs_configuration.rb
+++ b/opsworks_nodejs/libraries/nodejs_configuration.rb
@@ -3,7 +3,7 @@ module OpsWorks
     def self.npm_install(app_name, app_config, app_root_path, npm_install_options)
       if File.exists?("#{app_root_path}/package.json")
         Chef::Log.info("package.json detected. Running npm #{npm_install_options}.")
-        Chef::Log.info(OpsWorks::ShellOut.shellout("cd #{app_root_path} && sudo -Hu #{app_config[:user]} 'npm #{npm_install_options}' 2>&1"))
+        Chef::Log.info(OpsWorks::ShellOut.shellout("cd #{app_root_path} && sudo -Hu #{app_config[:user]} npm #{npm_install_options} 2>&1"))
       end
     end
   end


### PR DESCRIPTION
su - www-data fails with ubuntu 14.04, it just echoes "This account is currently not available.", since www-data has a nologin shell.

filed as PR against opsworks as well: https://github.com/aws/opsworks-cookbooks/pull/234
