### PR TITLE
Bugfix: rsyslogd: ~ is deprecated, use stop instead

### DIFF
--- a/rsyslogd/files/default/10-mute.conf
+++ b/rsyslogd/files/default/10-mute.conf
@@ -1,3 +1,3 @@
-:msg, startswith, " (root) CMD (/etc/ganglia/scripts/" ~
-:msg, isequal, " (root) CMD ()" ~
-:msg, ereregex, " pam_unix\(cron:session\): session (closed|opened) for user root" ~
+:msg, startswith, " (root) CMD (/etc/ganglia/scripts/" stop
+:msg, isequal, " (root) CMD ()" stop
+:msg, ereregex, " pam_unix\(cron:session\): session (closed|opened) for user root" stop


### PR DESCRIPTION
Fixes: "Warning: ~ action is deprecated, consider using the 'stop' statement instead [try http://www.rsyslog.com/e/2307 ]"

There is another rsyslog-conf which still triggers the error, but that config is ubuntu-default, should probably be fixed soon.
