### PR TITLE
Bugfix: haproxy error pages do not have http headers

### DIFF
--- a/haproxy/templates/default/haproxy.monit.erb
+++ b/haproxy/templates/default/haproxy.monit.erb
@@ -2,4 +2,4 @@ check process <%= @app_name %>
   with pidfile "<%= @pid_file %>"
   start program = "<%= @init %> start"
   stop program = "<%= @init %> stop"
-  if failed port 80 protocol http for 3 cycles then restart
+  if failed port 80 for 3 cycles then restart


### PR DESCRIPTION
...so protocol http will fail and restart haproxy, which happens sometimes during deployments or an outage
