### PR TITLE
Disable RC4 ssl to remove chrome warning

### DIFF
--- a/easybib-deploy/templates/default/nginx-ssl.conf.erb
+++ b/easybib-deploy/templates/default/nginx-ssl.conf.erb
@@ -4,7 +4,7 @@ server {
   ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
   ssl_certificate <%= @ssl_dir %>/cert.pem;
   ssl_certificate_key <%= @ssl_dir %>/cert.key;
-  ssl_ciphers RC4:HIGH:!aNULL:!MD5@STRENGTH;
+  ssl_ciphers HIGH:!RC4:!eNULL:!aNULL:!MD5@STRENGTH;
   ssl_prefer_server_ciphers on;
 
   access_log off;


### PR DESCRIPTION
Improves security while all relevant browser still can connect according to qualys
