### PR TITLE
Improve HTTPS config for rr

### DIFF
--- a/nginx-app/templates/default/infolit.conf.erb
+++ b/nginx-app/templates/default/infolit.conf.erb
@@ -11,9 +11,7 @@ server {
 
 server {
 
-<% if !node['opsworks'] -%>
-    listen 80;
-<% else -%>
+<% if ::EasyBib.is_aws(node) -%>
     listen 443;
 
     ssl                       on;
@@ -22,6 +20,8 @@ server {
     ssl_certificate_key       /etc/nginx/ssl/cert.key;
     ssl_ciphers               HIGH:!RC4:!eNULL:!aNULL:!MD5@STRENGTH;
     ssl_prefer_server_ciphers on;
+<% else -%>
+    listen 80;
 <% end -%>
 
 <% if @nginx_extra -%>
@@ -95,7 +95,7 @@ server {
   <% if !@environment.nil? && !@environment.empty? -%>
       fastcgi_param BIB_ENV "<%=@environment%>";
   <% end -%>
-<% if node['opsworks'] -%>
+<% if ::EasyBib.is_aws(node) -%>
       fastcgi_param HTTPS on;
 <% end -%>
       fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
- Sets SSL Ciphers to same settings as easybib.com https://github.com/till/easybib-cookbooks/pull/537
- Enables $_SERVER['https'] header (cc @glaubinix)
