### PR TITLE
First working version of haproxy 1.5 with ssl

### DIFF
--- a/easybib-deploy/attributes/default.rb
+++ b/easybib-deploy/attributes/default.rb
@@ -1,5 +1,6 @@
 default['ssl-deploy'] = {}
 default['ssl-deploy']['directory'] = '/etc/nginx/ssl'
+default['ssl-deploy']['ssl-role'] = 'nginxphpapp'
 
 default['bibcd']['apps'] = {}
 default['travis-asset-browser']['config'] = {

--- a/easybib-deploy/recipes/ssl-certificates.rb
+++ b/easybib-deploy/recipes/ssl-certificates.rb
@@ -2,7 +2,7 @@ ssl_dir    = node['ssl-deploy']['directory']
 
 node['deploy'].each do |application, deploy|
 
-  next unless allow_deploy(application, 'ssl', 'nginxphpapp')
+  next unless allow_deploy(application, 'ssl', node['ssl-deploy']['ssl-role'])
 
   unless deploy.key?('ssl_certificate')
     Chef::Log.info("No ssl_certificate 'key'")
@@ -63,7 +63,6 @@ node['deploy'].each do |application, deploy|
     variables(
       'ssl_key' => ssl_combined_key
     )
-    notifies :restart, 'service[nginx]'
   end
 
 end

--- a/easybib-deploy/recipes/ssl-certificates.rb
+++ b/easybib-deploy/recipes/ssl-certificates.rb
@@ -26,7 +26,7 @@ node['deploy'].each do |application, deploy|
 
   ssl_certificate     = deploy['ssl_certificate'].chomp
   ssl_certificate_key = deploy['ssl_certificate_key'].chomp
-  ssl_combined_key    = [ssl_certificate,ssl_certificate_key].join("\n")
+  ssl_combined_key    = [ssl_certificate, ssl_certificate_key].join("\n")
 
   directory ssl_dir do
     mode      '0750'

--- a/easybib-deploy/recipes/ssl-certificates.rb
+++ b/easybib-deploy/recipes/ssl-certificates.rb
@@ -26,6 +26,7 @@ node['deploy'].each do |application, deploy|
 
   ssl_certificate     = deploy['ssl_certificate'].chomp
   ssl_certificate_key = deploy['ssl_certificate_key'].chomp
+  ssl_combined_key    = [ssl_certificate,ssl_certificate_key].join("\n")
 
   directory ssl_dir do
     mode      '0750'
@@ -52,6 +53,17 @@ node['deploy'].each do |application, deploy|
     variables(
       'ssl_key' => ssl_certificate_key
     )
+  end
+
+  template ssl_dir + '/cert.combined.pem' do
+    source 'ssl_key.erb'
+    mode   '0640'
+    owner  'root'
+    group  node['nginx-app']['group']
+    variables(
+      'ssl_key' => ssl_combined_key
+    )
+    notifies :restart, 'service[nginx]'
   end
 
 end

--- a/easybib-deploy/recipes/ssl.rb
+++ b/easybib-deploy/recipes/ssl.rb
@@ -8,11 +8,9 @@ int_ip        = node['nginx-lb']['int_ip']
 
 if is_aws
   instance_roles = get_instance_roles
-  cluster_name   = get_cluster_name
 else
   Chef::Log.debug('Not running on AWS, setting defaults.')
   instance_roles = ''
-  cluster_name   = ''
 end
 
 stored_certificate = false
@@ -49,7 +47,7 @@ node['deploy'].each do |application, deploy|
 
   ssl_certificate     = deploy['ssl_certificate'].chomp
   ssl_certificate_key = deploy['ssl_certificate_key'].chomp
-  ssl_combined_key = [ssl_certificate,ssl_certificate_key].join("\n")
+  ssl_combined_key = [ssl_certificate, ssl_certificate_key].join("\n")
 
   directory ssl_dir do
     mode      '0750'

--- a/easybib/recipes/role-nginxapp-infolit.rb
+++ b/easybib/recipes/role-nginxapp-infolit.rb
@@ -1,7 +1,7 @@
 include_recipe 'easybib::role-phpapp'
 
 if is_aws
-  include_recipe 'easybib-deploy::ssl-infolit'
+  include_recipe 'easybib-deploy::ssl-certificates'
   include_recipe 'easybib-deploy::infolit'
 else
   include_recipe 'nginx-app::vagrant'

--- a/haproxy/attributes/customize.rb
+++ b/haproxy/attributes/customize.rb
@@ -9,6 +9,8 @@ default['haproxy']['errorloc'] = {
   '504' => '5xx.http'
 }
 
+default['haproxy']['type'] = '1.4' # 1.4 or 1.5
+default['haproxy']['ssl'] = 'off' # off, on, only - on/only works only with 1.5
 default['haproxy']['ctl'] = {}
 default['haproxy']['ctl']['version'] = '1.1.0'
 default['haproxy']['ctl']['base_path'] = '/usr/local/share'

--- a/haproxy/recipes/default.rb
+++ b/haproxy/recipes/default.rb
@@ -16,6 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+apt_repository 'haproxy' do
+  distribution  node['lsb']['codename']
+  uri           'ppa:vbernat/haproxy-1.5'
+  only_if { node['haproxy']['type'] == '1.5' }
+end
+
 package 'haproxy' do
   action :install
 end

--- a/haproxy/templates/default/haproxy.cfg.frontend.erb
+++ b/haproxy/templates/default/haproxy.cfg.frontend.erb
@@ -1,11 +1,14 @@
-<%
-# bind haproxy to the following parameters
-haproxy_port = 80
-haproxy_host = ""
--%>
-
 frontend http-in
-  bind <%= haproxy_host %>:<%= haproxy_port %>
+  bind *:80
+  <% unless @node['haproxy']['ssl'] == 'off'
+    certificate = "#{@node['ssl-deploy']['directory']}/cert.combined.pem"
+  -%>
+  bind *:443 ssl crt <%= certificate %>
+  http-request add-header X-Proto https if { ssl_fc }
+  <% if @node['haproxy']['ssl'] == 'only' -%>
+  redirect scheme https if !{ ssl_fc }
+  <% end
+  end -%>
   option log-separate-errors
 
   <% if !@node['haproxy']['acls'].nil? || @node['haproxy']['acls'].empty?  -%>

--- a/haproxy/templates/default/haproxy.cfg.globals.erb
+++ b/haproxy/templates/default/haproxy.cfg.globals.erb
@@ -7,6 +7,9 @@ global
   user haproxy
   group haproxy
   stats socket /tmp/haproxy.sock level admin
+<% if @node['haproxy']['type'] == '1.5' -%>
+  tune.ssl.default-dh-param 2048
+<% end -%>
 
 defaults
   log             global
@@ -15,9 +18,15 @@ defaults
   option          dontlognull
   retries         3
   maxconn         2000
+<% if @node['haproxy']['type'] == '1.5' -%>
+  timeout connect 50000
+  timeout client  50000
+  timeout server  50000
+<% else -%>
   contimeout      50000
   clitimeout      50000
   srvtimeout      50000
+<% end -%>
   option          redispatch
   option          httpclose     # disable keepalive (HAProxy does not yet support the HTTP keep-alive mode)
   option          abortonclose  # enable early dropping of aborted requests from pending queue

--- a/monit/recipes/service.rb
+++ b/monit/recipes/service.rb
@@ -3,5 +3,6 @@ service 'monit' do
   action :nothing
 end
 
+include_recipe 'monit'
 include_recipe 'monit::mailnotify'
 include_recipe 'monit::systemcheck'

--- a/nginx-lb/attributes/default.rb
+++ b/nginx-lb/attributes/default.rb
@@ -1,5 +1,4 @@
 default['nginx-lb']['role']    = 'lb'
-default['nginx-lb']['cluster'] = ['Fruitkid', 'Fruitkid Playground', 'EasyBib Playground', 'EasyBib']
 default['nginx-lb']['dir']     = '/etc/nginx'
 default['nginx-lb']['int_ip']  = '127.0.0.1'
 default['nginx-lb']['user']    = 'www-data'

--- a/vagrant-test/haproxy-ssl/Vagrantfile
+++ b/vagrant-test/haproxy-ssl/Vagrantfile
@@ -1,0 +1,46 @@
+# set box names and locations of cookbooks
+box_url  = 'https://s3.amazonaws.com/easybibdeployment/easybib-ubuntu-14.04.1_vbox-4.3.12_chef-11.10.4_0.1.box'
+box_file = 'easybib-ubuntu-14.04.1_vbox-4.3.12_chef-11.10.4_0.1'
+
+Vagrant.configure('2') do |config|
+
+  bibconfig = Bib::Vagrant::Config.new
+  vagrantconfig = bibconfig.get
+
+  config.vm.define :vagrant do |vagrant_config|
+    vagrant_config.vm.box     = box_file
+    vagrant_config.vm.box_url = box_url
+
+    vagrant_config.vm.hostname = 'vagrant'
+    vagrant_config.vm.network :private_network, :ip => '10.11.12.4'
+
+    vagrant_config.vm.provider :virtualbox do |vb|
+      vb.gui = vagrantconfig['gui']
+
+      vb.customize [
+        'modifyvm', :id,
+        '--name', 'Vagrant Testbox',
+        '--memory', '1024'
+      ]
+    end
+
+    dna = JSON.parse(File.read("#{File.expand_path(File.dirname(__FILE__))}/web-dna.json"))
+
+    # uncomment the next line and re-run provision if you end up with a
+    # "Failed to fetch mirror://mirrors.ubuntu.com/mirrors.txt" error:
+    # vagrant_config.vm.provision "shell", inline: "apt-spy2 fix --commit"
+
+    vagrant_config.vm.provision 'shell', :inline => 'apt-get update -y'
+
+    vagrant_config.vm.provision :chef_solo do |chef|
+
+      chef.cookbooks_path = vagrantconfig['cookbook_path']
+      chef.log_level = :debug
+
+      chef.add_recipe 'easybib-deploy::ssl-certificates'
+      chef.add_recipe 'haproxy'
+
+      chef.json = dna
+    end
+  end
+end

--- a/vagrant-test/haproxy-ssl/web-dna.json
+++ b/vagrant-test/haproxy-ssl/web-dna.json
@@ -2,7 +2,11 @@
   "haproxy" : {
     "additional_layers": {},
     "acls": {},
+    "ssl": "on",
     "type": "1.5"
+  },
+  "ssl-deploy": {
+    "ssl-role": "lb"
   },
   "deploy": {
     "ssl": {

--- a/vagrant-test/haproxy-ssl/web-dna.json
+++ b/vagrant-test/haproxy-ssl/web-dna.json
@@ -1,0 +1,25 @@
+{
+  "haproxy" : {
+    "additional_layers": {},
+    "acls": {},
+    "type": "1.5"
+  },
+  "deploy": {
+    "ssl": {
+      "ssl_certificate": "-----BEGIN CERTIFICATE-----\nMIICOzCCAaQCCQDPWkBP5VrRtDANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJE\nRTEPMA0GA1UECBMGQmVybGluMQ8wDQYDVQQHEwZCZXJsaW4xGTAXBgNVBAoTEFRp\nbGwgS2xhbXBhZWNrZWwxFjAUBgNVBAMTDXZhZ3JhbnQubG9jYWwwHhcNMTIwODI0\nMTM0MTIxWhcNMTMwODI0MTM0MTIxWjBiMQswCQYDVQQGEwJERTEPMA0GA1UECBMG\nQmVybGluMQ8wDQYDVQQHEwZCZXJsaW4xGTAXBgNVBAoTEFRpbGwgS2xhbXBhZWNr\nZWwxFjAUBgNVBAMTDXZhZ3JhbnQubG9jYWwwgZ8wDQYJKoZIhvcNAQEBBQADgY0A\nMIGJAoGBAL9pcseQ0pOJ22rKP889Nr4LT9bg0oBCa/+x79TkBeBuxQ5j5QCjxKeY\ntIQNz0r1bom+fT8wRFq8kz0z/UFMdhwjXIxSYTHe3zaTB+2QrcNjp3Z7yq1wgHfk\n1pkpheg1Ob8wKZvScc6s1GWMWknlBBh2hHvxfefC3c+KJ/JxYqhBAgMBAAEwDQYJ\nKoZIhvcNAQEFBQADgYEABA6Qi6aVfBrM2ltS967WTZimhnfgN6Y+SrGfUozioOJW\nNyYPV4Dp1NjtYvdZLci2eSp2bFPLLnN7L1GYZT0F+p0cBmeTEhTsuGbFxmAxjq+g\nU7LcfYZT7505PNLLBPBl8kgfMr5aO7aAEE59h2MX2Dx/Vcea8xpqG5Pqumf4Ol0=\n-----END CERTIFICATE-----",
+      "ssl_certificate_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXgIBAAKBgQC/aXLHkNKTidtqyj/PPTa+C0/W4NKAQmv/se/U5AXgbsUOY+UA\no8SnmLSEDc9K9W6Jvn0/MERavJM9M/1BTHYcI1yMUmEx3t82kwftkK3DY6d2e8qt\ncIB35NaZKYXoNTm/MCmb0nHOrNRljFpJ5QQYdoR78X3nwt3PiifycWKoQQIDAQAB\nAoGAKPrbfwxrePjnyAo69RSG9tMXKcsCZkFSO/ENhse21mEAwV7ztVpajQMtiqQm\nQEchfk4RJIkh6Uc8QrsxulwzYN0xCa9NHuFmXXH/uVwH/+3y1SEYMeL1WNYxX4c0\nWry2E8ZFMkPbaRFrgQr9ukJhcWejcyF4V4n0kU+wCXa3FlECQQD9LCrLrCyXLZc7\n698YbbHXoBpeNKwgAFikhd+FQGbFVg366rEbkNa1ehgM4j6Mj7s97GlPdAKNcYFD\nLiaVOWh1AkEAwYy0Wo6Xucb9khf2iU2WyyAZW3fYkeMt+8zjvcfVPJGZAiQkJk8P\n7OfuwlxFN7pWvhRT3IZGA00eolLeABgnHQJBAJgYjK1HhpJcJVsuXR0D6a+s06p8\n4ltnWdmdQ6d+BT/Qbx2rGTOCVDs6WnCDCyjOwKJ3AN1myJHI+ustMqi7kHECQQCN\nakzsTXs2Vdo3wCJ1t6cRyuY8Gpi2HxMeA1ny8+stUgRFuDphcyrjoaKlh91bFl8C\nir+rRMAq8VIMsBdcYklRAkEAq2BbN3FsLrxGj49Yu4W4x9nsfNy2xZaNMoD2wz/J\npSFUjzfIc290wCoyoxSRIbYDPeEwQg2q1K/UNRdMBRw30A==\n-----END RSA PRIVATE KEY-----"
+    }
+  },
+    "opsworks": {
+      "instance": {
+        "layers": ["lb"]
+      },
+      "layers": {
+        "nginxphpapp": {
+          "instances": {
+          
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
This still needs to be added (together with `easybib-deploy::ssl-certificates`) to a role to be fully working, but we have to discuss the opsworks setup first.