### PR TITLE
Bugfix: Make sure we stop nginx immediately

### DIFF
--- a/nginx-lb/recipes/configure.rb
+++ b/nginx-lb/recipes/configure.rb
@@ -5,5 +5,5 @@ nginx_app_config 'nginx-lb: nginx.conf' do
   enable_fastcgi false
   nginx_user node['nginx-lb']['user']
   nginx_group node['nginx-lb']['user']
-  notifies :stop, 'service[nginx]'
+  notifies :stop, 'service[nginx]', :immediately
 end


### PR DESCRIPTION
If we start/restart later, we could end up with being "stop" issued as the last command