### PR TITLE
Bugfix: Use nscd service definition in avahi recipes

### DIFF
--- a/avahi/metadata.rb
+++ b/avahi/metadata.rb
@@ -7,3 +7,5 @@ version           '0.1'
 recipe            'avahi::default', 'Installs avahi'
 
 supports 'ubuntu'
+
+depends 'easybib'

--- a/avahi/recipes/alias.rb
+++ b/avahi/recipes/alias.rb
@@ -1,3 +1,4 @@
+include_recipe 'easybib::nscd'
 include_recipe 'avahi::alias-service'
 
 ['python-avahi', 'python-pip'].each do |pkg|

--- a/avahi/recipes/default.rb
+++ b/avahi/recipes/default.rb
@@ -1,3 +1,5 @@
+include_recipe 'easybib::nscd'
+
 # installs avahi-daemon
 package 'avahi-daemon'
 

--- a/easybib/recipes/nscd.rb
+++ b/easybib/recipes/nscd.rb
@@ -1,0 +1,6 @@
+package 'nscd'
+
+service 'nscd' do
+  action :nothing
+  supports [:start, :stop, :restart, :reload]
+end

--- a/easybib/recipes/setup.rb
+++ b/easybib/recipes/setup.rb
@@ -1,7 +1,7 @@
 base_packages = [
   'htop', 'jwhois', 'multitail',
   'apache2-utils', 'strace', 'rsync',
-  'manpages', 'manpages-dev', 'nscd',
+  'manpages', 'manpages-dev',
   'git-core', 'unzip', 'realpath', 'curl'
 ]
 
@@ -16,11 +16,7 @@ chef_gem 'BibOpsworks' do
   end
 end
 
-service 'nscd' do
-  action :nothing
-  supports [:start, :stop, :restart, :reload]
-end
-
+include_recipe 'easybib::nscd'
 include_recipe 'easybib::nginxstats'
 include_recipe 'easybib::cron'
 include_recipe 'easybib::ruby'


### PR DESCRIPTION
We'll run into a race condition otherwise if avahi is called before easybib::setup