### PR TITLE
Bugfix: Typo: It is easybib_deploy in json

### DIFF
--- a/nginx-app/templates/default/hhvm.conf.erb
+++ b/nginx-app/templates/default/hhvm.conf.erb
@@ -24,9 +24,9 @@ server {
 
     root <%= @doc_root%>;
 
-    <% unless @node.fetch('easybib-deploy', {}).fetch('hhvm', {})['asset_root'].nil? -%>
+    <% unless @node.fetch('easybib_deploy', {}).fetch('hhvm', {})['asset_root'].nil? -%>
 <%= render "partials/production-asset-route.erb", :cookbook => 'nginx-app', :variables => {
-    "asset_root" => @node['easybib-deploy']['hhvm']['asset_root']
+    "asset_root" => @node['easybib_deploy']['hhvm']['asset_root']
     } %>
     <% end %>
 

--- a/nginx-app/templates/default/silex.conf.erb
+++ b/nginx-app/templates/default/silex.conf.erb
@@ -32,9 +32,9 @@ server {
         set $fastcgi_skipcache 0;
     }
 
-    <% unless @node.fetch('easybib-deploy', {}).fetch('scholar', {})['asset_root'].nil? -%>
+    <% unless @node.fetch('easybib_deploy', {}).fetch('scholar', {})['asset_root'].nil? -%>
 <%= render "partials/production-asset-route.erb", :cookbook => 'nginx-app', :variables => {
-    "asset_root" => @node['easybib-deploy']['scholar']['asset_root']
+    "asset_root" => @node['easybib_deploy']['scholar']['asset_root']
     } %>
     <% end %>
 


### PR DESCRIPTION
node['easybib-deploy'] can later be removed from stack.json. already duplicated it to `node['easybib_deploy']`