### PR TITLE
Bugfix: Wrong syslog timestamps

### DIFF
--- a/rsyslogd/files/default/01-fix-timestamp.conf
+++ b/rsyslogd/files/default/01-fix-timestamp.conf
@@ -1,0 +1,5 @@
+# RepeatedMsgReduction screws up timestamps
+# http://serverfault.com/questions/608690/weird-syslog-order
+# http://bugzilla.adiscon.com/show_bug.cgi?id=527
+$RepeatedMsgReduction off
+

--- a/rsyslogd/recipes/default.rb
+++ b/rsyslogd/recipes/default.rb
@@ -9,4 +9,9 @@ cookbook_file '/etc/rsyslog.d/10-debug-helper.conf' do
   mode 0644
 end
 
+cookbook_file '/etc/rsyslog.d/01-fix-timestamp.conf' do
+  source '01-fix-timestamp.conf'
+  mode 0644
+end
+
 include_recipe 'rsyslogd::mute-cron'


### PR DESCRIPTION
There is a known bug in syslog for trusty resulting in weird off timestamps for "compacted" log entries:

![bug](https://cloud.githubusercontent.com/assets/40325/6483293/9f705a82-c26f-11e4-93ea-0c29523c7319.png)

This disables compacting

* http://serverfault.com/questions/608690/weird-syslog-order
* http://bugzilla.adiscon.com/show_bug.cgi?id=527