### PR TITLE
use plain-http rubygems as a source for BibOpsworks

### DIFF
--- a/easybib/recipes/setup.rb
+++ b/easybib/recipes/setup.rb
@@ -10,6 +10,7 @@ base_packages.each do |p|
 end
 
 chef_gem 'BibOpsworks' do
+  options('--clear-sources http://rubygems.org/')
   action :install
   only_if do
     ::EasyBib.is_aws(node)

--- a/easybib/recipes/setup.rb
+++ b/easybib/recipes/setup.rb
@@ -10,7 +10,7 @@ base_packages.each do |p|
 end
 
 chef_gem 'BibOpsworks' do
-  options('--clear-sources http://rubygems.org/')
+  options('--clear-sources --source http://rubygems.org/')
   action :install
   only_if do
     ::EasyBib.is_aws(node)


### PR DESCRIPTION
to work around https://tickets.opscode.com/browse/CHEF-4436

Stolen from http://stackoverflow.com/questions/21141045/change-gem-source-to-chef-cookbook-dependency
No idea if this even works, much less if it's a good idea. I couldn't find anything about how to do this for all `chef_gem`s so I just did it for the one that failed