### PR TITLE
Bugfix: Do not upload vendors to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - make test
 
 before_deploy:
-  - tar cfz easybib-cookbooks.tar.gz * --exclude=easybib-cookbooks.tar.gz
+  - tar cfz easybib-cookbooks.tar.gz * --exclude=easybib-cookbooks.tar.gz --exclude=vendor/
   - mkdir build
   - mv easybib-cookbooks.tar.gz build/
 


### PR DESCRIPTION
Currently `vendor/*` is added to the tarball for s3, resulting in 150mb cookbooks.