### PR TITLE
Easybib nginx changes to support public-api and easybib in plaground

### DIFF
--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -41,7 +41,7 @@ node['deploy'].each do |application, deploy|
 
   domain_name_trim = configured_domains.split[0]
   config_name_2 = "#{domain_name_trim}.conf"
-  Chef::Log.info("nginx-app::configure - config file: #{config_name}")
+  Chef::Log.info("nginx-app::configure - config file: #{config_name_2}")
 
   template "render vhost: #{application}" do
     path   "#{nginx_config_dir}/sites-enabled/#{config_name}"
@@ -65,31 +65,6 @@ node['deploy'].each do |application, deploy|
       :doc_root           => ::EasyBib::Config.get_appdata(node, application, 'doc_root_dir'),
       :app_dir            => ::EasyBib::Config.get_appdata(node, application, 'app_dir')
     )
-    notifies :restart, 'service[nginx]', :delayed
-  end
-
-  template "render vhost: #{application}" do
-    path   "#{nginx_config_dir}/sites-enabled/#{config_name_2}"
-    source nginx_config
-    mode   '0755'
-    owner  node['nginx-app']['user']
-    group  node['nginx-app']['group']
-    helpers EasyBib::Helpers
-    variables(
-      :domain_name        => configured_domains,
-      :js_alias           => node['nginx-app']['js_modules'],
-      :img_alias          => node['nginx-app']['img_modules'],
-      :css_alias          => node['nginx-app']['css_modules'],
-      :access_log         => app_access_log,
-      :deploy             => deploy,
-      :password_protected => password_protected,
-      :config_dir         => nginx_config_dir,
-      :php_upstream       => ::EasyBib.get_upstream_from_pools(node['php-fpm']['pools'], node['php-fpm']['socketdir']),
-      :upstream_name      => application,
-      :environment        => ::EasyBib.get_cluster_name(node),
-      :doc_root           => ::EasyBib::Config.get_appdata(node, application, 'doc_root_dir'),
-      :app_dir            => ::EasyBib::Config.get_appdata(node, application, 'app_dir')
-              )
     notifies :restart, 'service[nginx]', :delayed
   end
 

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -13,7 +13,7 @@ node['deploy'].each do |application, deploy|
 
 
   configured_domains = ::EasyBib::Config.get_domains(node, application)
-  config_file_name = configured_domains.split()[0].concat('conf')
+  config_file_name = configured_domains.split()[0] + ".conf"
   
   Chef::Log.info("nginx-app::configure - app: #{application}")
 

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -11,6 +11,10 @@ config_name = 'easybib.com.conf'
 
 node['deploy'].each do |application, deploy|
 
+
+  configured_domains = ::EasyBib::Config.get_domains(node, application)
+  config_file_name = configured_domains.split()[0].concat('conf')
+  
   Chef::Log.info("nginx-app::configure - app: #{application}")
 
   case application
@@ -36,14 +40,16 @@ node['deploy'].each do |application, deploy|
     next
   end
 
+  Chef::Log.info("nginx-app::configure - file: #{config_file_name}")
   template "render vhost: #{application}" do
-    path   "#{nginx_config_dir}/sites-enabled/#{config_name}"
+    path   "#{nginx_config_dir}/sites-enabled/#{config_file_name}"
     source nginx_config
     mode   '0755'
     owner  node['nginx-app']['user']
     group  node['nginx-app']['group']
     helpers EasyBib::Helpers
     variables(
+      :server_name        => configured_domains,
       :js_alias           => node['nginx-app']['js_modules'],
       :img_alias          => node['nginx-app']['img_modules'],
       :css_alias          => node['nginx-app']['css_modules'],

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -7,14 +7,12 @@ nginx_config_dir = node['nginx-app']['config_dir']
 password_protected = false
 
 nginx_config = node['nginx-app']['conf_file']
-config_name = 'easybib.com.conf'
+# config_name = 'easybib.com.conf'
 
 node['deploy'].each do |application, deploy|
-
-
   configured_domains = ::EasyBib::Config.get_domains(node, application)
-  config_file_name = configured_domains.split()[0] + ".conf"
-  
+  config_file_name = configured_domains.split[0] + '.conf'
+
   Chef::Log.info("nginx-app::configure - app: #{application}")
 
   case application
@@ -69,5 +67,4 @@ node['deploy'].each do |application, deploy|
   easybib_envconfig application do
     stackname 'easybib'
   end
-
 end

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -39,10 +39,6 @@ node['deploy'].each do |application, deploy|
   configured_domains = ::EasyBib::Config.get_domains(node, application, env_conf)
   Chef::Log.info("nginx-app::configure - domains: #{configured_domains}")
 
-  domain_name_trim = configured_domains.split[0]
-  config_name_2 = "#{domain_name_trim}.conf"
-  Chef::Log.info("nginx-app::configure - config file: #{config_name_2}")
-
   template "render vhost: #{application}" do
     path   "#{nginx_config_dir}/sites-enabled/#{config_name}"
     source nginx_config

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -7,13 +7,9 @@ nginx_config_dir = node['nginx-app']['config_dir']
 password_protected = false
 
 nginx_config = node['nginx-app']['conf_file']
-# config_name = 'easybib.com.conf'
+config_name = 'easybib.com.conf'
 
 node['deploy'].each do |application, deploy|
-  configured_domains = ::EasyBib::Config.get_domains(node, application)
-  config_domain = configured_domains.split[0]
-  config_file_name = "#{config_domain}.conf"
-
   Chef::Log.info("nginx-app::configure - app: #{application}")
 
   case application
@@ -39,9 +35,12 @@ node['deploy'].each do |application, deploy|
     next
   end
 
-  Chef::Log.info("nginx-app::configure - file: #{config_file_name}")
+  env_conf = ::EasyBib::Config.get_env('nginx', application, node)
+  configured_domains = ::EasyBib::Config.get_domains(node, application, env_conf)
+  Chef::Log.info("nginx-app::configure - domains: #{configured_domains}")
+
   template "render vhost: #{application}" do
-    path   "#{nginx_config_dir}/sites-enabled/#{config_file_name}"
+    path   "#{nginx_config_dir}/sites-enabled/#{config_name}"
     source nginx_config
     mode   '0755'
     owner  node['nginx-app']['user']

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -51,7 +51,7 @@ node['deploy'].each do |application, deploy|
     group  node['nginx-app']['group']
     helpers EasyBib::Helpers
     variables(
-      :server_name        => configured_domains,
+      :domain_name        => configured_domains,
       :js_alias           => node['nginx-app']['js_modules'],
       :img_alias          => node['nginx-app']['img_modules'],
       :css_alias          => node['nginx-app']['css_modules'],

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -11,7 +11,8 @@ nginx_config = node['nginx-app']['conf_file']
 
 node['deploy'].each do |application, deploy|
   configured_domains = ::EasyBib::Config.get_domains(node, application)
-  config_file_name = configured_domains.split[0] + '.conf'
+  config_domain = configured_domains.split[0]
+  config_file_name = "#{config_domain}.conf"
 
   Chef::Log.info("nginx-app::configure - app: #{application}")
 

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -39,9 +39,9 @@ node['deploy'].each do |application, deploy|
   configured_domains = ::EasyBib::Config.get_domains(node, application, env_conf)
   Chef::Log.info("nginx-app::configure - domains: #{configured_domains}")
 
-  domain_name_trim = configured_domains.split[0]
-  config_name = "#{domain_name_trim}.conf"
-  Chef::Log.info("nginx-app::configure - config file: #{config_name}")
+  # domain_name_trim = configured_domains.split[0]
+  # config_name = "#{domain_name_trim}.conf"
+  # Chef::Log.info("nginx-app::configure - config file: #{config_name}")
 
   template "render vhost: #{application}" do
     path   "#{nginx_config_dir}/sites-enabled/#{config_name}"

--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -39,6 +39,10 @@ node['deploy'].each do |application, deploy|
   configured_domains = ::EasyBib::Config.get_domains(node, application, env_conf)
   Chef::Log.info("nginx-app::configure - domains: #{configured_domains}")
 
+  domain_name_trim = configured_domains.split[0]
+  config_name = "#{domain_name_trim}.conf"
+  Chef::Log.info("nginx-app::configure - config file: #{config_name}")
+
   template "render vhost: #{application}" do
     path   "#{nginx_config_dir}/sites-enabled/#{config_name}"
     source nginx_config


### PR DESCRIPTION
I made some what seems to be minor changes to nginx-app/recipes/configure.rb to support the domain name <-> server_name option in the /etc/nginx/sites-enabled/*.conf files for easybib.com.

I did some tests to see if I could change the conf name and other tests to probe what I can do here.

I also did testing on playground.easybib.com and this appears to work OK.
