### PR TITLE
Remove nginx search config for infolit

### DIFF
--- a/nginx-app/templates/default/infolit.conf.erb
+++ b/nginx-app/templates/default/infolit.conf.erb
@@ -79,14 +79,6 @@ server {
     <%= render 'partials/php-fpm.erb',
       :cookbook => 'nginx-app',
       :variables => {
-        :index => 'search.php',
-        :location => '/search/'
-      }
-    %>
-
-    <%= render 'partials/php-fpm.erb',
-      :cookbook => 'nginx-app',
-      :variables => {
         :index => 'index.php',
         :location => '/'
       }


### PR DESCRIPTION
search is not used anymore
also should we enable it again than it should be handled via app not separate file