### PR TITLE
Relocating the decision if crontab deployment is allowed

### DIFF
--- a/easybib/providers/crontab.rb
+++ b/easybib/providers/crontab.rb
@@ -12,7 +12,8 @@ action :create do
   execute 'Clear old crontab' do
     user node['nginx-app']['user']
     # crontab will exit with 130 if crontab has already been cleared
-    command "crontab -u #{node['nginx-app']['user']} -r"
+    # adding a "; true" to remove the loooong warning in chef logs everyone stumbles upon
+    command "crontab -u #{node['nginx-app']['user']} -r; true"
     ignore_failure true
     only_if do
       ::File.exist?(crontab_file)
@@ -21,36 +22,45 @@ action :create do
 
   execute 'Clear old cron.d files' do
     # rm will exit with 1 if no old cron.d files existed
-    command "rm /etc/cron.d/#{app}_*"
+    # adding a "; true" to remove the loooong warning in chef logs everyone stumbles upon
+    command "rm /etc/cron.d/#{app}_*; true"
     ignore_failure true
   end
 
   Chef::Log.info("easybib_deploy - importing cronjobs from #{crontab_file}")
 
-  cron = ::EasyBib::Cron.new(app, crontab_file)
+  create_crontab = ::EasyBib.deploy_crontab?(
+    new_resource.instance_roles,
+    new_resource.cronjob_role
+  )
+  if create_crontab
+    cron = ::EasyBib::Cron.new(app, crontab_file)
 
-  cron.parse!.to_enum.with_index(1).each do |crontab, cron_counter|
-    Chef::Log.info("easybib_deploy - crontabline: #{crontab}")
+    cron.parse!.to_enum.with_index(1).each do |crontab, cron_counter|
+      Chef::Log.info("easybib_deploy - crontabline: #{crontab}")
 
-    updated = true
-    cron_name = cron.get_name(cron_counter)
+      updated = true
+      cron_name = cron.get_name(cron_counter)
 
-    Chef::Log.info("easybib_deploy - installing crontab file #{cron_name}")
+      Chef::Log.info("easybib_deploy - installing crontab file #{cron_name}")
 
-    cron_d cron_name do
-      action :create
-      minute crontab[1]
-      hour crontab[2]
-      day crontab[3]
-      month crontab[4]
-      weekday crontab[5]
-      user node['nginx-app']['user']
-      command crontab[6]
-      path node['easybib_deploy']['cron_path']
+      cron_d cron_name do
+        action :create
+        minute crontab[1]
+        hour crontab[2]
+        day crontab[3]
+        month crontab[4]
+        weekday crontab[5]
+        user node['nginx-app']['user']
+        command crontab[6]
+        path node['easybib_deploy']['cron_path']
+      end
+
+      Chef::Log.info("easybib_deploy - I just called cron_d for #{cron_name}")
+
     end
-
-    Chef::Log.info("easybib_deploy - I just called cron_d for #{cron_name}")
-
+  else
+    Chef::Log.info('easybib_deploy - I did not install cronjobs because deploy_crontab returned false')
   end
 
   new_resource.updated_by_last_action(updated)

--- a/easybib/providers/deploy.rb
+++ b/easybib/providers/deploy.rb
@@ -34,12 +34,8 @@ action :deploy do
   easybib_crontab "#{app}_#{new_resource.cronjob_role}" do
     crontab_file "#{application_root_dir}/deploy/crontab"
     app app
-    only_if do
-      ::EasyBib.deploy_crontab?(
-        instance_roles,
-        cronjob_role
-      )
-    end
+    cronjob_role cronjob_role
+    instance_roles instance_roles
   end
 
   easybib_supervisor "#{app}_supervisor" do

--- a/easybib/resources/crontab.rb
+++ b/easybib/resources/crontab.rb
@@ -4,3 +4,5 @@ default_action :create
 
 attribute :app, :default => ''
 attribute :crontab_file, :kind_of => String, :default => ''
+attribute :instance_roles, :default => []
+attribute :cronjob_role, :kind_of => String, :default => nil

--- a/easybib/spec/easybib_crontab_spec.rb
+++ b/easybib/spec/easybib_crontab_spec.rb
@@ -25,7 +25,7 @@ describe 'easybib_crontab' do
       before { stub_crontab_with_one_valid_and_one_invalid_line }
 
       it 'cleans leftover old crontab' do
-        expect(chef_run).to run_execute('crontab -u www-data -r')
+        expect(chef_run).to run_execute('crontab -u www-data -r; true')
       end
 
       it 'creates a cronjob' do


### PR DESCRIPTION
This way, we always clean up old cronjobs. Otherwise, when we enable the cronjob_role, old cronjobs are not removed