### PR TITLE
Bugfix: Php seems sometimes not do determine sendmail path correct

### DIFF
--- a/php-fpm/templates/default/php.ini.erb
+++ b/php-fpm/templates/default/php.ini.erb
@@ -70,7 +70,7 @@ date.timezone = America/New_York
 define_syslog_variables  = Off
 
 [mail function]
-;sendmail_path =
+sendmail_path = /usr/sbin/sendmail -t -i
 ;mail.force_extra_parameters =
 mail.add_x_header = On
 ;mail.log =


### PR DESCRIPTION
For whatever random reason, php seems to sometimes just omit `/usr/sbin/sendmail`, 
thus resulting in a broken mail command