### PR TITLE
Cleanups with ppa handling

### DIFF
--- a/nginx-app/attributes/default.rb
+++ b/nginx-app/attributes/default.rb
@@ -6,7 +6,7 @@ default['nginx-app']['static_directories'] = %w(js css images raw)
 default['nginx-app']['config_dir']         = '/etc/nginx'
 default['nginx-app']['conf_file']          = 'easybib.com.conf.erb'
 default['nginx-app']['package-name'] = 'nginx'
-default['nginx-app']['ppa'] = ::EasyBib::Ppa.ppa_mirror(node, 'ppa:easybib/remote-mirrors')
+default['nginx-app']['ppa'] = 'ppa:easybib/remote-mirrors'
 default['nginx-app']['client_max_body_size'] = '5m'
 
 default['nginx-app']['extras'] = ''

--- a/nginx-app/recipes/ppa.rb
+++ b/nginx-app/recipes/ppa.rb
@@ -1,7 +1,7 @@
 include_recipe 'aptly::gpg'
 
 apt_repository 'nginx-ppa' do
-  uri           node['nginx-app']['ppa']
+  uri           ::EasyBib::Ppa.ppa_mirror(node, node['nginx-app']['ppa'])
   distribution  node['lsb']['codename']
   components    ['main']
 end

--- a/php-fpm/attributes/default.rb
+++ b/php-fpm/attributes/default.rb
@@ -23,6 +23,5 @@ default['php-fpm']['ini'] = {
 }
 
 default['php-fpm']['packages'] = 'php5-easybib,php5-easybib-mbstring,php5-easybib-memcache'
-default['php-fpm']['ppa'] = ::EasyBib::Ppa.ppa_mirror(node, 'ppa:easybib/php55')
 
 default['php-fpm']['mailsender'] = nil

--- a/redis/attributes/default.rb
+++ b/redis/attributes/default.rb
@@ -19,7 +19,7 @@ default['redis']['rdb'] = {
   'keys_changed' => 0
 }
 
-default['redis']['ppa'] = ::EasyBib::Ppa.ppa_mirror(node, 'ppa:chris-lea/redis-server')
+default['redis']['ppa'] = 'ppa:chris-lea/redis-server'
 
 # master-slave configuration, allow overriding from opsworks/upstream
 set_unless['redis']['master']             = {}

--- a/redis/recipes/default.rb
+++ b/redis/recipes/default.rb
@@ -1,7 +1,7 @@
 include_recipe 'aptly::gpg'
 
 apt_repository 'redis-ppa' do
-  uri           node['redis']['ppa']
+  uri           ::EasyBib::Ppa.ppa_mirror(node, node['redis']['ppa'])
   distribution  node['lsb']['codename']
   components    ['main']
 end


### PR DESCRIPTION
* removed an unused ppa attribute
* relocate all easybib::ppa calls to the receipe, so it can be used even if the originating ppa is changed in the node attr