### PR TITLE
Only configure supervisor if the instance has supervisor_role

### DIFF
--- a/easybib/libraries/easybib.rb
+++ b/easybib/libraries/easybib.rb
@@ -19,6 +19,18 @@ module EasyBib
 
     false
   end
+  
+  def has_role?(instance_roles, role)
+    if role.nil?
+      return true
+    end
+
+    if instance_roles.include?(role)
+      return true
+    end
+
+    false
+  end
 
   def has_env?(app, node = self.node)
     unless node.attribute?(app)

--- a/easybib/libraries/easybib.rb
+++ b/easybib/libraries/easybib.rb
@@ -19,7 +19,7 @@ module EasyBib
 
     false
   end
-  
+
   def has_role?(instance_roles, role)
     if role.nil?
       return true

--- a/easybib/providers/deploy.rb
+++ b/easybib/providers/deploy.rb
@@ -3,8 +3,10 @@ action :deploy do
   deploy_data = new_resource.deploy_data
   cronjob_role = new_resource.cronjob_role
   instance_roles = new_resource.instance_roles
+  supervisor_role = new_resource.supervisor_role
 
   cronjob_role = node['easybib_deploy']['cronjob_role'] if cronjob_role.nil?
+  supervisor_role = node['easybib_deploy']['supervisor_role'] if supervisor_role.nil?
   instance_roles = ::EasyBib.get_instance_roles(node) if instance_roles.empty?
 
   application_root_dir = "#{deploy_data['deploy_to']}/current"
@@ -43,6 +45,8 @@ action :deploy do
     app app
     app_dir application_root_dir
     user deploy_data['user']
+    supervisor_role supervisor_role
+    instance_roles instance_roles
   end
 
   easybib_gearmanw application_root_dir do

--- a/easybib/providers/supervisor.rb
+++ b/easybib/providers/supervisor.rb
@@ -2,11 +2,21 @@ action :create do
   app = new_resource.app
   app_dir = new_resource.app_dir
   supervisor_file = new_resource.supervisor_file
+  supervisor_role = new_resource.supervisor_role
   user = new_resource.user
 
   updated = false
 
   unless ::File.exist?(supervisor_file)
+    new_resource.updated_by_last_action(updated)
+    next
+  end
+  
+  unless ::EasyBib.has_role?(
+    new_resource.instance_roles,
+    supervisor_role
+  )
+    Chef::Log.info('easybib_deploy - I did not install supervisor because instance does not have the #{supervisor_role} role')
     new_resource.updated_by_last_action(updated)
     next
   end

--- a/easybib/providers/supervisor.rb
+++ b/easybib/providers/supervisor.rb
@@ -11,7 +11,7 @@ action :create do
     new_resource.updated_by_last_action(updated)
     next
   end
-  
+
   unless ::EasyBib.has_role?(
     new_resource.instance_roles,
     supervisor_role

--- a/easybib/resources/deploy.rb
+++ b/easybib/resources/deploy.rb
@@ -6,4 +6,5 @@ attribute :app, :default => {}
 attribute :deploy_data, :default => {}
 attribute :envvar_json_source, :kind_of => String, :default => nil
 attribute :cronjob_role, :kind_of => String, :default => nil
+attribute :supervisor_role, :kind_of => String, :default => nil
 attribute :instance_roles, :default => []

--- a/easybib/resources/supervisor.rb
+++ b/easybib/resources/supervisor.rb
@@ -6,3 +6,4 @@ attribute :app, :kind_of => String, :default => ''
 attribute :app_dir, :kind_of => String, :default => ''
 attribute :supervisor_file, :kind_of => String, :default => ''
 attribute :user, :kind_of => String, :default => ''
+attribute :supervisor_role, :kind_of => String, :default => nil

--- a/easybib/resources/supervisor.rb
+++ b/easybib/resources/supervisor.rb
@@ -7,3 +7,4 @@ attribute :app_dir, :kind_of => String, :default => ''
 attribute :supervisor_file, :kind_of => String, :default => ''
 attribute :user, :kind_of => String, :default => ''
 attribute :supervisor_role, :kind_of => String, :default => nil
+attribute :instance_roles, :default => []

--- a/easybib/tests/test_easybib.rb
+++ b/easybib/tests/test_easybib.rb
@@ -116,6 +116,27 @@ class TestEasyBib < Test::Unit::TestCase
       true
     )
   end
+  
+  def test_has_role_no_role
+    assert_equal(
+      has_role?([], nil),
+      true
+    )
+  end
+
+  def test_has_role_wrong_role
+    assert_equal(
+      has_role?(%w(role1 role2), 'housekeeping'),
+      false
+    )
+  end
+
+  def test_has_role_right_role
+    assert_equal(
+      has_role?(%w(role1 housekeeping), 'housekeeping'),
+      true
+    )
+  end
 
   def test_normalized_cluster_name
     fake_node = Chef::Node.new

--- a/easybib/tests/test_easybib.rb
+++ b/easybib/tests/test_easybib.rb
@@ -2,6 +2,7 @@ require 'test/unit'
 require 'chef'
 require File.join(File.dirname(__FILE__), '../libraries', 'easybib.rb')
 
+# rubocop:disable ClassLength
 class TestEasyBib < Test::Unit::TestCase
   include EasyBib
 

--- a/easybib/tests/test_easybib.rb
+++ b/easybib/tests/test_easybib.rb
@@ -116,7 +116,7 @@ class TestEasyBib < Test::Unit::TestCase
       true
     )
   end
-  
+
   def test_has_role_no_role
     assert_equal(
       has_role?([], nil),


### PR DESCRIPTION
https://github.com/easybib/issues/issues/4393

This will allow RabbitMQ consumers to be run only on a single instance.