### PR TITLE
Make id default server for api stack

### DIFF
--- a/easybib-deploy/recipes/silex.rb
+++ b/easybib-deploy/recipes/silex.rb
@@ -7,13 +7,13 @@ node['deploy'].each do |application, deploy|
   when 'api'
     next unless allow_deploy(application, 'api', 'nginxphpapp')
   when 'discover_api'
-    listen_opts = 'default_server'
     next unless allow_deploy(application, 'discover_api', 'nginxphpapp')
   when 'featureflags'
     next unless allow_deploy(application, 'featureflags', 'nginxphpapp')
   when 'scholar_admin'
     next unless allow_deploy(application, 'scholar_admin', 'nginxphpapp')
   when 'id'
+    listen_opts = 'default_server'
     next unless allow_deploy(application, 'id', 'nginxphpapp')
   else
     Chef::Log.info("deploy::silex - #{application} skipped")


### PR DESCRIPTION
references https://github.com/easybib/issues/issues/4429#issuecomment-121266147

Warning: Health check url for id is different, this might cause a downtime if ELB is not adjusted accordingly when updating cookbooks!'