### PR TITLE
Adapt to new package mirror structure

### DIFF
--- a/apt/attributes/default.rb
+++ b/apt/attributes/default.rb
@@ -1,6 +1,5 @@
 default['apt'] = {}
-default['apt']['easybib'] = {}
-default['apt']['easybib']['ppa'] = 'ppa:easybib/php55'
+default['apt']['php_mirror_version'] = '55'
 default['apt']['upgrade-package'] = nil
 default['apt']['launchpad_api_version'] = '1.0'
 default['apt']['cacher-client']['restrict_environment'] = false

--- a/apt/attributes/default.rb
+++ b/apt/attributes/default.rb
@@ -1,5 +1,4 @@
 default['apt'] = {}
-default['apt']['php_mirror_version'] = '55'
 default['apt']['upgrade-package'] = nil
 default['apt']['launchpad_api_version'] = '1.0'
 default['apt']['cacher-client']['restrict_environment'] = false

--- a/apt/recipes/easybib.rb
+++ b/apt/recipes/easybib.rb
@@ -2,7 +2,7 @@ include_recipe 'apt::ppa'
 include_recipe 'aptly::gpg'
 
 apt_repository 'easybib-ppa' do
-  uri           ::EasyBib::Ppa.ppa_mirror(node, node['apt']['easybib']['ppa'])
+  uri           ::EasyBib::Ppa.ppa_mirror(node)
   distribution  node['lsb']['codename']
   components    ['main']
 end

--- a/aptly/providers/cronjob.rb
+++ b/aptly/providers/cronjob.rb
@@ -1,35 +1,33 @@
 action :create do
   path = new_resource.path
 
-  %w(55 56).each do |version|
-    s3_mirror = "#{node['aptly']['s3_mirror']}:#{node['aptly']['s3_mirror_prefix']}#{version}"
-    pw = node['aptly']['sign_pass']
+  s3_mirror = "#{node['aptly']['s3_mirror']}:#{node['aptly']['s3_mirror_prefix']}#{version}"
+  pw = node['aptly']['sign_pass']
 
-    template "#{path}/run#{version}.sh" do
-      source 'run.sh.erb'
-      cookbook 'aptly'
-      owner 'root'
-      group 'root'
-      mode 00700
-      variables(
-        :pw => pw,
-        :s3_mirror => s3_mirror,
-        :path => path,
-        :version => version
-      )
-      action :create
-    end
-
-    cron_command = "screen -d -m #{path}/run#{version}.sh"
-
-    cron_d 'aptly_sync_launchpad' do
-      action :create
-      minute '0'
-      hour '5'
-      user 'root'
-      command cron_command
-      path node['easybib_deploy']['cron_path']
-    end
-    new_resource.updated_by_last_action(true)
+  template "#{path}/run.sh" do
+    source 'run.sh.erb'
+    cookbook 'aptly'
+    owner 'root'
+    group 'root'
+    mode 00700
+    variables(
+      :pw => pw,
+      :s3_mirror => s3_mirror,
+      :path => path,
+      :version => version
+    )
+    action :create
   end
+
+  cron_command = "screen -d -m #{path}/run.sh"
+
+  cron_d 'aptly_sync_launchpad' do
+    action :create
+    minute '0'
+    hour '5'
+    user 'root'
+    command cron_command
+    path node['easybib_deploy']['cron_path']
+  end
+  new_resource.updated_by_last_action(true)
 end

--- a/easybib/attributes/default.rb
+++ b/easybib/attributes/default.rb
@@ -6,4 +6,7 @@ default['easybib_deploy']['cron_path']     = '/usr/local/bin:/usr/bin:/bin'
 default['easybib_deploy']['deploy_action'] = :reload
 default['easybib_deploy']['use_newrelic']  = 'no'
 default['easybib_deploy']['envtype']       = 'playground'
-default['easybib_deploy']['cronjob_role'] = nil
+default['easybib_deploy']['cronjob_role']  = nil
+
+default['easybib']['enable_ppa_mirror']  = false
+default['easybib']['php_mirror_version'] = '55'

--- a/easybib/libraries/ppa.rb
+++ b/easybib/libraries/ppa.rb
@@ -7,7 +7,7 @@ module EasyBib
     end
 
     def enable_aptly_mirror?(node = self.node)
-      enable_ppa_mirror = node.fetch('apt', {}).fetch('enable_ppa_mirror', false)
+      enable_ppa_mirror = node.fetch('easybib', {}).fetch('enable_ppa_mirror', false)
       unless enable_ppa_mirror
         # enable trusty mirror is an old param, this check is for backwards compat
         enable_ppa_mirror = node.fetch('apt', {}).fetch('enable_trusty_mirror', false)
@@ -22,15 +22,15 @@ module EasyBib
 
     def php_launchpad_repo_url(node = self.node)
       prefix = 'ppa:easybib/php'
-      if node.fetch('apt', {})['php_mirror_version']
-        return prefix + node['apt']['php_mirror_version']
+      if node.fetch('easybib', {})['php_mirror_version']
+        return prefix + node['easybib']['php_mirror_version']
       end
       prefix + '55'
     end
 
     def php_mirror_repo_url(node = self.node)
       prefix = 'http://ppa.ezbib.com/mirrors/php'
-      prefix + node['apt']['php_mirror_version']
+      prefix + node['easybib']['php_mirror_version']
     end
 
     def ppa_mirror(node = self.node, standard_repo = 'easybib-php-ppa')

--- a/easybib/libraries/ppa.rb
+++ b/easybib/libraries/ppa.rb
@@ -20,10 +20,10 @@ module EasyBib
       known_distributions.include?(distribution)
     end
 
-    def repo_url(node = self.node, distribution)
-      prefix = 'http://ppa.ezbib.com/' + distribution
-      if node.fetch('apt', {})['ppa_mirror_version']
-        return prefix + node['apt']['ppa_mirror_version']
+    def php_repo_url(node = self.node, distribution)
+      prefix = 'http://ppa.ezbib.com/mirrors/php'
+      if node.fetch('apt', {})['php_mirror_version']
+        return prefix + node['apt']['php_mirror_version']
       end
       prefix + '55'
     end
@@ -32,8 +32,10 @@ module EasyBib
       unless use_aptly_mirror?(node)
         return standard_repo
       end
-      distribution = node.fetch('lsb', {})['codename']
-      repo_url(node, distribution)
+      if (standard_repo == node['apt']['easybib']['ppa'])
+        return php_repo_url(node)
+      end
+      'http://ppa.ezbib.com/mirrors/remote-mirrors'
     end
   end
 end

--- a/easybib/libraries/ppa.rb
+++ b/easybib/libraries/ppa.rb
@@ -20,21 +20,32 @@ module EasyBib
       known_distributions.include?(distribution)
     end
 
-    def php_repo_url(node = self.node, distribution)
-      prefix = 'http://ppa.ezbib.com/mirrors/php'
+    def php_launchpad_repo_url(node = self.node)
+      prefix = 'ppa:easybib/php'
       if node.fetch('apt', {})['php_mirror_version']
         return prefix + node['apt']['php_mirror_version']
       end
       prefix + '55'
     end
 
-    def ppa_mirror(node = self.node, standard_repo)
+    def php_mirror_repo_url(node = self.node)
+      prefix = 'http://ppa.ezbib.com/mirrors/php'
+      prefix + node['apt']['php_mirror_version']
+    end
+
+    def ppa_mirror(node = self.node, standard_repo = 'easybib-php-ppa')
+      if (standard_repo == 'easybib-php-ppa')
+        if use_aptly_mirror?(node)
+          return php_mirror_repo_url(node)
+        else
+          return php_launchpad_repo_url(node)
+        end
+      end
+
       unless use_aptly_mirror?(node)
         return standard_repo
       end
-      if (standard_repo == node['apt']['easybib']['ppa'])
-        return php_repo_url(node)
-      end
+
       'http://ppa.ezbib.com/mirrors/remote-mirrors'
     end
   end

--- a/easybib/tests/test_ppa.rb
+++ b/easybib/tests/test_ppa.rb
@@ -38,6 +38,7 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_php_mirror_repo_url
     fake_node = Chef::Node.new
+    fake_node.set['apt']['php_mirror_version'] = '55'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php55',
       php_mirror_repo_url(fake_node)
@@ -89,12 +90,14 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_php_ppa_mirror
     fake_node = Chef::Node.new
+    fake_node.set['apt']['php_mirror_version'] = '55'
     assert_equal(
       'ppa:easybib/php55',
       ppa_mirror(fake_node)
     )
     fake_node = Chef::Node.new
     fake_node.set['apt']['enable_ppa_mirror'] = false
+    fake_node.set['apt']['php_mirror_version'] = '55'
     assert_equal(
       'ppa:easybib/php55',
       ppa_mirror(fake_node, 'ppa:easybib/php55')
@@ -102,6 +105,7 @@ class TestEasyBib < Test::Unit::TestCase
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
     fake_node.set['apt']['enable_ppa_mirror'] = true
+    fake_node.set['apt']['php_mirror_version'] = '55'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php55',
       ppa_mirror(fake_node)

--- a/easybib/tests/test_ppa.rb
+++ b/easybib/tests/test_ppa.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/ClassLength
 require 'test/unit'
 require 'chef'
 require File.join(File.dirname(__FILE__), '../libraries', 'ppa.rb')
@@ -34,22 +36,21 @@ class TestEasyBib < Test::Unit::TestCase
     )
   end
 
-  def test_repo_url
+  def test_php_mirror_repo_url
     fake_node = Chef::Node.new
     assert_equal(
-      'http://ppa.ezbib.com/distrib55',
-      repo_url(fake_node, 'distrib')
+      'http://ppa.ezbib.com/mirrors/php55',
+      php_mirror_repo_url(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['apt']['ppa_mirror_version'] = '56'
+    fake_node.set['apt']['php_mirror_version'] = '56'
     assert_equal(
-      'http://ppa.ezbib.com/trusty56',
-      repo_url(fake_node, 'trusty')
+      'http://ppa.ezbib.com/mirrors/php56',
+      php_mirror_repo_url(fake_node)
     )
   end
 
-  # rubocop:disable Metrics/MethodLength
-  def test_ppa_mirror
+  def test_remote_ppa_mirror
     fake_node = Chef::Node.new
     assert_equal(
       'http://something.com',
@@ -73,17 +74,45 @@ class TestEasyBib < Test::Unit::TestCase
     fake_node.set['lsb']['codename'] = 'trusty'
     fake_node.set['apt']['enable_ppa_mirror'] = true
     assert_equal(
-      'http://ppa.ezbib.com/trusty55',
+      'http://ppa.ezbib.com/mirrors/remote-mirrors',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
     fake_node.set['apt']['enable_ppa_mirror'] = true
-    fake_node.set['apt']['ppa_mirror_version'] = '56'
+    fake_node.set['apt']['php_mirror_version'] = '56'
     assert_equal(
-      'http://ppa.ezbib.com/trusty56',
+      'http://ppa.ezbib.com/mirrors/remote-mirrors',
       ppa_mirror(fake_node, 'http://something.com')
     )
   end
-  # rubocop:enable Metrics/MethodLength
+
+  def test_php_ppa_mirror
+    fake_node = Chef::Node.new
+    assert_equal(
+      'ppa:easybib/php55',
+      ppa_mirror(fake_node)
+    )
+    fake_node = Chef::Node.new
+    fake_node.set['apt']['enable_ppa_mirror'] = false
+    assert_equal(
+      'ppa:easybib/php55',
+      ppa_mirror(fake_node, 'ppa:easybib/php55')
+    )
+    fake_node = Chef::Node.new
+    fake_node.set['lsb']['codename'] = 'trusty'
+    fake_node.set['apt']['enable_ppa_mirror'] = true
+    assert_equal(
+      'http://ppa.ezbib.com/mirrors/php55',
+      ppa_mirror(fake_node)
+    )
+    fake_node = Chef::Node.new
+    fake_node.set['lsb']['codename'] = 'trusty'
+    fake_node.set['apt']['enable_ppa_mirror'] = true
+    fake_node.set['apt']['php_mirror_version'] = '56'
+    assert_equal(
+      'http://ppa.ezbib.com/mirrors/php56',
+      ppa_mirror(fake_node)
+    )
+  end
 end

--- a/easybib/tests/test_ppa.rb
+++ b/easybib/tests/test_ppa.rb
@@ -15,21 +15,21 @@ class TestEasyBib < Test::Unit::TestCase
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'precise'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       false,
       use_aptly_mirror?(fake_node)
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = false
+    fake_node.set['easybib']['enable_ppa_mirror'] = false
     assert_equal(
       false,
       use_aptly_mirror?(fake_node)
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       true,
       use_aptly_mirror?(fake_node)
@@ -38,13 +38,13 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_php_mirror_repo_url
     fake_node = Chef::Node.new
-    fake_node.set['apt']['php_mirror_version'] = '55'
+    fake_node.set['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php55',
       php_mirror_repo_url(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['apt']['php_mirror_version'] = '56'
+    fake_node.set['easybib']['php_mirror_version'] = '56'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php56',
       php_mirror_repo_url(fake_node)
@@ -59,29 +59,29 @@ class TestEasyBib < Test::Unit::TestCase
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'precise'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       'http://something.com',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = false
+    fake_node.set['easybib']['enable_ppa_mirror'] = false
     assert_equal(
       'http://something.com',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       'http://ppa.ezbib.com/mirrors/remote-mirrors',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
-    fake_node.set['apt']['php_mirror_version'] = '56'
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['php_mirror_version'] = '56'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/remote-mirrors',
       ppa_mirror(fake_node, 'http://something.com')
@@ -90,30 +90,30 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_php_ppa_mirror
     fake_node = Chef::Node.new
-    fake_node.set['apt']['php_mirror_version'] = '55'
+    fake_node.set['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'ppa:easybib/php55',
       ppa_mirror(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['apt']['enable_ppa_mirror'] = false
-    fake_node.set['apt']['php_mirror_version'] = '55'
+    fake_node.set['easybib']['enable_ppa_mirror'] = false
+    fake_node.set['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'ppa:easybib/php55',
       ppa_mirror(fake_node, 'ppa:easybib/php55')
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
-    fake_node.set['apt']['php_mirror_version'] = '55'
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php55',
       ppa_mirror(fake_node)
     )
     fake_node = Chef::Node.new
     fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['apt']['enable_ppa_mirror'] = true
-    fake_node.set['apt']['php_mirror_version'] = '56'
+    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.set['easybib']['php_mirror_version'] = '56'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php56',
       ppa_mirror(fake_node)


### PR DESCRIPTION
references https://github.com/easybiblabs/mirror-it/pull/12

This also removes `node[apt][easybib][ppa]` - since we always use the `remote-mirrors` ppa for everything except php, there is now a `node[easybib][php_mirror_version]` version instead. Current default is `55`.