### PR TITLE
always redirect iescholar.com to www.iescholar.com

### DIFF
--- a/easybib/libraries/helpers.rb
+++ b/easybib/libraries/helpers.rb
@@ -7,5 +7,9 @@ module EasyBib
     def fetch_node(node, app, *args)
       ::EasyBib::Config.node(node, app, args)
     end
+    
+    def get_www_redirect_name(domain_name)
+      return domain_name.split(' ').select { |d| d.start_with?('www.') }.map { |d| d[4..-1] }.join(' ')
+    end
   end
 end

--- a/easybib/libraries/helpers.rb
+++ b/easybib/libraries/helpers.rb
@@ -9,7 +9,7 @@ module EasyBib
     end
     
     def get_www_redirect_name(domain_name)
-      return domain_name.split(' ').select { |d| d.start_with?('www.') }.map { |d| d[4..-1] }.join(' ')
+      domain_name.split(' ').select { |d| d.start_with?('www.') }.map { |d| d[4..-1] }.join(' ')
     end
   end
 end

--- a/easybib/libraries/helpers.rb
+++ b/easybib/libraries/helpers.rb
@@ -7,7 +7,7 @@ module EasyBib
     def fetch_node(node, app, *args)
       ::EasyBib::Config.node(node, app, args)
     end
-    
+
     def get_www_redirect_name(domain_name)
       domain_name.split(' ').select { |d| d.start_with?('www.') }.map { |d| d[4..-1] }.join(' ')
     end

--- a/nginx-app/templates/default/scholar.conf.erb
+++ b/nginx-app/templates/default/scholar.conf.erb
@@ -1,6 +1,6 @@
 <% enable_caching = node.fetch('nginx-app', {}).fetch('browser_caching', {})['enabled'] %>
 <%= render_upstream(@php_upstream, @upstream_name) %>
-<% redirect_name = @domain_name.split(' ').select { |d| d.start_with?('www.') }.map { |d| d[4..-1] }.join(' ') %>
+<% redirect_name = get_www_redirect_name(@domain_name) %>
 
 <% if !redirect_name.nil? && !redirect_name.empty? -%>
 server {

--- a/nginx-app/templates/default/scholar.conf.erb
+++ b/nginx-app/templates/default/scholar.conf.erb
@@ -1,5 +1,14 @@
 <% enable_caching = node.fetch('nginx-app', {}).fetch('browser_caching', {})['enabled'] %>
 <%= render_upstream(@php_upstream, @upstream_name) %>
+<% redirect_name = @domain_name.split(' ').select { |d| d.start_with?('www.') }.map { |d| d[4..-1] }.join(' ') %>
+
+<% if !redirect_name.nil? && !redirect_name.empty? -%>
+server {
+    listen 80;
+    server_name <%=redirect_name%>;
+    return 301 https://www.$host$request_uri;
+}
+<% end -%>
 
 server {
     set $fastcgi_skipcache 1; # skip by default


### PR DESCRIPTION
https://github.com/easybib/issues/issues/4620

If the site has any domain names starting with `www.` a 301 redirect will be setup for the non-www version of the domain name.

This has been tested on playground by adding a www. domain to the playground config & deploying the branch.