### PR TITLE
Reverting bced80e37982783064275654e6a864d2f5236b4a

### DIFF
--- a/easybib/attributes/default.rb
+++ b/easybib/attributes/default.rb
@@ -1,12 +1,11 @@
-default['easybib_deploy'] = {
-  'gearman_file' => 'pecl_manager_env',
-  'env_source' => nil,
-  'provide_pear' => false,
-  'cron_path' => '/usr/local/bin:/usr/bin:/bin',
-  'use_newrelic' => 'no',
-  'envtype' => 'playground',
-  'cronjob_role' => nil
-}
-
+default['easybib_deploy']                  = {}
+default['easybib_deploy']['gearman_file']  = 'pecl_manager_env'
+default['easybib_deploy']['env_source']    = nil
+default['easybib_deploy']['provide_pear']  = false
+default['easybib_deploy']['cron_path']     = '/usr/local/bin:/usr/bin:/bin'
+default['easybib_deploy']['use_newrelic']  = 'no'
+default['easybib_deploy']['envtype']       = 'playground'
+default['easybib_deploy']['cronjob_role']  = nil
+default['easybib_deploy']['supervisor_role'] = 'consumer'
 default['easybib']['enable_ppa_mirror']  = false
 default['easybib']['php_mirror_version'] = '55'


### PR DESCRIPTION
This will blow up attribute merging since we currently use it in easybib and easybib_deploy.

Please note: This fails rubocop, but the failure reason is in the upstream branch, not in the change here.