### PR TITLE
supervisor provider: add process_name config option

### DIFF
--- a/easybib/providers/supervisor.rb
+++ b/easybib/providers/supervisor.rb
@@ -60,7 +60,8 @@ action :create do
       'environment' => {},
       'directory' => nil,
       'umask' => nil,
-      'serverurl' => 'AUTO'
+      'serverurl' => 'AUTO',
+      'process_name' => '%(program_name)s'
     }
 
     config.merge!(service)
@@ -71,6 +72,7 @@ action :create do
       command "#{app_dir}/#{config['command']}"
       numprocs config['numprocs']
       numprocs_start config['numprocs_start']
+      process_name config['process_name']
       priority config['priority']
       autostart config['autostart']
       startsecs config['startsecs']


### PR DESCRIPTION
so we can set num_procs (which requires process_name to include
the process_num)

default set to "%(program_name)s", which is supervisord's default

http://supervisord.org/configuration.html