### PR TITLE
apache-couchdb compile fail during scholar-vagrant web provisioning

### DIFF
--- a/apache-couchdb/recipes/configure.rb
+++ b/apache-couchdb/recipes/configure.rb
@@ -14,7 +14,7 @@ node['apache-couchdb']['config'].each do |section, config|
   if section == 'admins'
     ini_file = "#{local_dir}/local.ini"
   else
-    ini_file = "#{local_dir}/#{section.ini}"
+    ini_file = "#{local_dir}/#{section}.ini"
   end
 
   template ini_file do # ~FC022


### PR DESCRIPTION
Asia was having this error:
```
==> web: Recipe Compile Error in /tmp/vagrant-chef/bd4f646c7a6520a257e59062d7313745/cookbooks/scholar/recipes/role-vagrant.rb
```
which I drilled down to:
```
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Loading Recipe apache-couchdb via include_recipe
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Found recipe default in cookbook apache-couchdb
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Loading Recipe apt::ppa via include_recipe
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Found recipe ppa in cookbook apt
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Loading Recipe apache-couchdb::configure via include_recipe
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Found recipe configure in cookbook apache-couchdb
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Loading Recipe apache-couchdb::service via include_recipe
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Found recipe service in cookbook apache-couchdb
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Loading Recipe logrotate via include_recipe
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Found recipe default in cookbook logrotate
==> web: [2015-09-28T18:30:03+00:00] DEBUG: filtered backtrace of compile error: /tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:17:in `block in from_file',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:12:in `each',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:12:in `from_file',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/default.rb:11:in `from_file',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/scholar/recipes/role-vagrant.rb:7:in `from_file'
==> web: [2015-09-28T18:30:03+00:00] DEBUG: filtered backtrace of compile error: /tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:17:in `block in from_file',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:12:in `each',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:12:in `from_file',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/default.rb:11:in `from_file',/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/scholar/recipes/role-vagrant.rb:7:in `from_file'
==> web: [2015-09-28T18:30:03+00:00] DEBUG: backtrace entry for compile error: '/tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/apache-couchdb/recipes/configure.rb:17:in `block in from_file''
==> web: [2015-09-28T18:30:03+00:00] DEBUG: Line number of compile error: '17'
==> web:
==> web: ================================================================================
==> web: Recipe Compile Error in /tmp/vagrant-chef/f5705899f051c84b079b835ca4ce852e/cookbooks/scholar/recipes/role-vagrant.rb
==> web: ================================================================================
==> web:
```

Looking in the change log for the configure.rb file I found:
```
-  template "/etc/couchdb/local.d/#{section}.ini" do
+
+  if section == 'admins'
+    ini_file = "#{local_dir}/local.ini"
+  else
+    ini_file = "#{local_dir}/#{section.ini}"
+  end
+
```

so i changed ```#{section.ini}``` to ```#{section}.ini``` thinking it was a typo and it seemed to work