### PR TITLE
Force restart of nginx when disabling upstart

### DIFF
--- a/nginx-app/recipes/service.rb
+++ b/nginx-app/recipes/service.rb
@@ -4,6 +4,7 @@ service 'nginx-upstart' do
   service_name 'nginx'
   action :stop
   provider Chef::Provider::Service::Upstart
+  notifies :restart, 'service[nginx]'
   only_if do
     ::File.exist?('/etc/init/nginx.conf')
   end
@@ -17,4 +18,5 @@ end
 service 'nginx' do
   provider Chef::Provider::Service::Init::Debian
   supports :status => true, :restart => true, :reload => true
+  action :start
 end

--- a/nginx-app/recipes/service.rb
+++ b/nginx-app/recipes/service.rb
@@ -1,3 +1,8 @@
+service 'nginx' do
+  provider Chef::Provider::Service::Init::Debian
+  supports :status => true, :restart => true, :reload => true
+end
+
 # Nginx installs an Upstart configuration by default. If this file
 # doesn't exist, Ubuntu will fall-back to prehistoric init-system.
 service 'nginx-upstart' do
@@ -13,10 +18,4 @@ end
 file '/etc/init/nginx.conf' do
   action :delete
   ignore_failure true
-end
-
-service 'nginx' do
-  provider Chef::Provider::Service::Init::Debian
-  supports :status => true, :restart => true, :reload => true
-  action :start
 end


### PR DESCRIPTION
The awesome `Upstart` hack from @till turned out to be not so awesome after all, unfortunately. The Nginx service is being reloaded gracefully instead of being restarted upon deployment, which effectively brings the entire web-server down.