### PR TITLE
Bugfix: Remove cron-mailto

### DIFF
--- a/ies/recipes/cron-mailto.rb
+++ b/ies/recipes/cron-mailto.rb
@@ -1,7 +1,0 @@
-cron 'Add our email into crontab' do
-  mailto node['sysop_email']
-
-  not_if do
-    node['sysop_email'].nil? || node['sysop_email'].empty?
-  end
-end

--- a/ies/recipes/role-generic.rb
+++ b/ies/recipes/role-generic.rb
@@ -1,7 +1,6 @@
 include_recipe 'ies::setup-basepackages'
 include_recipe 'ies::setup-bibopsworks' if is_aws
 include_recipe 'ies::nscd'
-include_recipe 'ies::cron-mailto'
 include_recipe 'ies::ruby-defaultgemrc'
 
 if is_aws


### PR DESCRIPTION
This does no longer work, and also creates an empty cronjob running every minute, spamming the logs