### PR TITLE
Fix: Ignore failures for supervisor workers in vagrant

### DIFF
--- a/nginx-app/recipes/vagrant.rb
+++ b/nginx-app/recipes/vagrant.rb
@@ -46,4 +46,5 @@ easybib_supervisor 'www_supervisor' do
   app_dir app_dir
   app 'www'
   user node['php-fpm']['user']
+  ignore_failure true
 end


### PR DESCRIPTION
This sometimes can fail in new vagrantenvs when composer was not yet executed.