### PR TITLE
Bugfix: Removes duplicate logrotate

### DIFF
--- a/redis/recipes/configure.rb
+++ b/redis/recipes/configure.rb
@@ -12,7 +12,15 @@ template '/etc/redis/redis.conf' do
   notifies :restart, 'service[redis-server]', :immediately
 end
 
-template '/etc/logrotate.d/redis' do
+# cleans up old logrotate file to remove duplicate warning
+file '/etc/logrotate.d/redis' do
+  action :delete
+  only_if do
+     File.exist?('/etc/logrotate.d/redis')
+   end
+end
+
+template '/etc/logrotate.d/redis-server' do
   source 'logrotate.erb'
   mode '0644'
   owner 'root'

--- a/redis/recipes/configure.rb
+++ b/redis/recipes/configure.rb
@@ -16,8 +16,8 @@ end
 file '/etc/logrotate.d/redis' do
   action :delete
   only_if do
-     File.exist?('/etc/logrotate.d/redis')
-   end
+    File.exist?('/etc/logrotate.d/redis')
+  end
 end
 
 template '/etc/logrotate.d/redis-server' do


### PR DESCRIPTION
ubuntu package creates /etc/logrotate.d/redis-server, we should overwrite this instead of creating a second one,
which then leads to "duplicate logfile" warning in logrotate