### PR TITLE
T/gitupdatesource

### DIFF
--- a/stack-qa/files/update_github_sources.sh
+++ b/stack-qa/files/update_github_sources.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# parent directory of github subdirs
+T_PROJECT_PATH='/srv/www/'
+
+# path to store logfiles
+T_LOG_PATH='/tmp/'
+
+# command to get a formatted date for log file names
+T_DATE=`date +%Y%m%d_%H%M`
+
+# list of github subdirs
+L_PATHS=`ls -1 /srv/www/`
+
+# git command
+C_GIT=`which git`
+
+# sudo command
+C_SUDO=`which sudo`
+
+V_USER='vagrantci'
+
+for V_FILE in ${L_PATHS}
+do
+	V_ACTION_PATH=${T_PROJECT_PATH}${V_FILE}/current
+	V_LOGFILE=${T_LOG_PATH}${T_DATE}_${V_FILE}.log
+	V_GROUP=`stat -c '%G' ${V_ACTION_PATH}`
+
+	# devine current branch
+	# V_BRANCH=`sudo -u ${V_USER} -g ${V_GROUP} bash -c "cd ${V_ACTION_PATH} && ${C_GIT} rev-parse --abbrev-ref HEAD"`
+
+	# ignore current branch
+	V_BRANCH="master"
+
+	# debug echoing 
+	# echo "Processing ${V_FILE} at ${V_ACTION_PATH} as ${V_LOGFILE} with ${V_BRANCH}"
+	# echo "sudo -u ${V_USER} -g ${V_GROUP} bash -c \"cd ${V_ACTION_PATH} && ${C_GIT} pull origin ${V_BRANCH} >> ${V_LOGFILE} 2>&1\""
+
+	# As the user of the vagrant and the group of the code group, get into the directory and do a git pull
+	# redirect ALL the output to a known file
+	sudo -u ${V_USER} bash -c "cd ${V_ACTION_PATH} && ${C_GIT} pull origin ${V_BRANCH} >> ${V_LOGFILE} 2>&1"
+done
+

--- a/stack-qa/files/update_github_sources.sh
+++ b/stack-qa/files/update_github_sources.sh
@@ -18,6 +18,7 @@ C_GIT=`which git`
 # sudo command
 C_SUDO=`which sudo`
 
+# this should be automated by chef, I don't know how yet
 V_USER='vagrantci'
 
 for V_FILE in ${L_PATHS}

--- a/stack-qa/recipes/deploy-vagrant-ci.rb
+++ b/stack-qa/recipes/deploy-vagrant-ci.rb
@@ -65,14 +65,12 @@ cookbook_file '/opt/vagrant/bin/update_github_sources.sh' do
   action :create
 end
 
-# setup git_update_script cron to run as deploy_user_name (has git creds)
+# setup git_update_script cron to run as root, script will pick up user with git creds
 cron 'cookbooks_report' do
   action :create
   minute '15'
   hour '1'
   day '*'
-  user deploy_user_name
-  home '#{deploy_user_home}/'
   command '/opt/vagrant/bin/update_github_sources.sh'
 end
 # END elements to setup git_updater

--- a/stack-qa/recipes/deploy-vagrant-ci.rb
+++ b/stack-qa/recipes/deploy-vagrant-ci.rb
@@ -55,6 +55,28 @@ file "#{deploy_user_home}/.ssh/id_dsa.pub" do
   end
 end
 
+# START elements to setup git_updater 
+# Install git_update_scrupt.sh from files directory
+cookbook_file '/opt/vagrant/bin/update_github_sources.sh' do
+  source 'update_github_sources.sh'
+  owner deploy_user_name
+  group deploy_user_name
+  mode '0755'
+  action :create
+end
+
+# setup git_update_script cron to run as deploy_user_name (has git creds)
+cron 'cookbooks_report' do
+  action :create
+  minute '15'
+  hour '1'
+  day '*'
+  user deploy_user_name
+  home '#{deploy_user_home}/'
+  command '/opt/vagrant/bin/update_github_sources.sh'
+end
+# END elements to setup git_updater
+
 node.default['bash']['environment'] = {
   'user' => deploy_user_name,
   'group' => deploy_user_name


### PR DESCRIPTION
This sorta works...

Chef recipe SHOULD install a file to ```/opt/vagrant/bin/update_github_sources.sh``` owned by the node's user and executable by all (is this bad?) and should also create a cron job that as root every day at 0115U will run said script.

Said script scans ```/srv/www/``` for sub dirs, then marches through each doing a git pull origin branch (master because I found that my auto-discovered branch ("deploy") doesn't really exist on origin) on each.  saving the output to ```/tmp/datetime_codebase.log```

