### PR TITLE
T/clean up

### DIFF
--- a/ies/recipes/opsworks-fixes.rb
+++ b/ies/recipes/opsworks-fixes.rb
@@ -1,7 +1,9 @@
-node['deploy'].each do |application, deploy|
-  if deploy['home'].nil? || deploy['home'] == '/home/www-data'
-    Chef::Log.debug('home was empty or /home/www, changing it to /var/www')
-    node.default['deploy'][application]['home'] = '/var/www'
+unless node['deploy'].nil?
+  node['deploy'].each do |application, deploy|
+    if deploy['home'].nil? || deploy['home'] == '/home/www-data'
+      Chef::Log.debug('home was empty or /home/www, changing it to /var/www')
+      node.default['deploy'][application]['home'] = '/var/www'
+    end
   end
 end
 

--- a/stack-service/recipes/role-statsd.rb
+++ b/stack-service/recipes/role-statsd.rb
@@ -1,13 +1,3 @@
-if !is_aws
-  include_recipe 'nodejs'
-else
-  # override deploy-user so it's only used by this recipe
-  node['deploy'].each do |app, deploy|
-    next unless allow_deploy(app, 'statsd', 'nodejs-app')
-    node.default['deploy'][app]['user'] = node['statsd']['user']
-    node.default['deploy'][app]['group'] = node['statsd']['group']
-    node.default['deploy'][app]['home'] = node['statsd']['deploy_dir']
-  end
-end
-
+include_recipe 'ies::role-generic'
+include_recipe 'nodejs'
 include_recipe 'statsd'

--- a/stack-service/recipes/role-statsd.rb
+++ b/stack-service/recipes/role-statsd.rb
@@ -3,8 +3,7 @@ if !is_aws
 else
   # override deploy-user so it's only used by this recipe
   node['deploy'].each do |app, deploy|
-    next unless allow_deploy(app, deployable_apps, deploy_role)
-    next if app != 'statsd'
+    next unless allow_deploy(app, 'statsd', 'nodejs-app')
     node.default['deploy'][app]['user'] = node['statsd']['user']
     node.default['deploy'][app]['group'] = node['statsd']['group']
     node.default['deploy'][app]['home'] = node['statsd']['deploy_dir']

--- a/stack-service/spec/role-statsd_spec.rb
+++ b/stack-service/spec/role-statsd_spec.rb
@@ -29,12 +29,7 @@ describe 'stack-service::role-statsd' do
     before do
       node.set['opsworks'] = {
         'instance' => {
-          'layers' => [
-            'mothership',
-            'borg',
-            'muddership',
-            'statsd'
-          ]
+          'layers' => %w(mothership borg muddership statsd)
         }
       }
       node.set['deploy'] = [

--- a/stack-service/spec/role-statsd_spec.rb
+++ b/stack-service/spec/role-statsd_spec.rb
@@ -18,31 +18,16 @@ describe 'stack-service::role-statsd' do
 
   let(:chef_run) { runner.converge(described_recipe) }
 
-  describe 'on localhost' do
-    it 'includes nodejs' do
+  describe 'stack-service::role-statsd' do
+    before do
+      node.set['easybib'] = {
+        'cluster_name' => 'vagrant-test'
+      }
+    end
+    it 'includes all recipes' do
+      expect(chef_run).to include_recipe('ies::role-generic')
       expect(chef_run).to include_recipe('nodejs')
       expect(chef_run).to include_recipe('statsd')
-    end
-  end
-
-  describe 'on OpsWorks' do
-    before do
-      node.set['opsworks'] = {
-        'instance' => {
-          'layers' => %w(mothership borg muddership statsd)
-        }
-      }
-      node.set['deploy'] = [
-        'statsd' => {
-          'user' => 'till',
-          'home' => '/home/till',
-          'group' => 'till'
-        }
-      ]
-    end
-
-    it 'does not include nodejs' do
-      expect(chef_run).not_to include_recipe('nodejs')
     end
   end
 end

--- a/stack-service/spec/role-statsd_spec.rb
+++ b/stack-service/spec/role-statsd_spec.rb
@@ -1,0 +1,53 @@
+require_relative 'spec_helper'
+
+describe 'stack-service::role-statsd' do
+
+  let(:cookbook_paths) do
+    [
+      File.expand_path("#{File.dirname(__FILE__)}/../../")
+    ]
+  end
+
+  let(:runner) do
+    ChefSpec::Runner.new(
+      :cookbook_path => cookbook_paths
+    )
+  end
+
+  let(:node) { runner.node }
+
+  let(:chef_run) { runner.converge(described_recipe) }
+
+  describe 'on localhost' do
+    it 'includes nodejs' do
+      expect(chef_run).to include_recipe('nodejs')
+      expect(chef_run).to include_recipe('statsd')
+    end
+  end
+
+  describe 'on OpsWorks' do
+    before do
+      node.set['opsworks'] = {
+        'instance' => {
+          'layers' => [
+            'mothership',
+            'borg',
+            'muddership',
+            'statsd'
+          ]
+        }
+      }
+      node.set['deploy'] = [
+        'statsd' => {
+          'user' => 'till',
+          'home' => '/home/till',
+          'group' => 'till'
+        }
+      ]
+    end
+
+    it 'does not include nodejs' do
+      expect(chef_run).not_to include_recipe('nodejs')
+    end
+  end
+end

--- a/stack-service/spec/spec_helper.rb
+++ b/stack-service/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'chefspec'
+
+RSpec.configure do |c|
+  c.platform = 'ubuntu'
+  c.version = '14.04'
+  #  c.log_level = :debug
+end

--- a/statsd/attributes/default.rb
+++ b/statsd/attributes/default.rb
@@ -2,8 +2,6 @@ default['librato'] = {}
 
 default['librato']['statsd']            = {}
 default['librato']['statsd']['etc_dir'] = '/etc/statsd'
-default['librato']['statsd']['user']    = 'root'
-default['librato']['statsd']['group']   = 'root'
 default['librato']['statsd']['port']    = 8125
 
 default['librato']['metrics']            = {}
@@ -15,6 +13,11 @@ default['statsd'] = {
   'deploy_dir' => '/opt/statsd',
   'repository' => 'git://github.com/easybiblabs/statsd.git',
   'branch' => 'deploy',
-  'user' => 'statsd',
-  'group' => 'statsd'
+  'user' => '_statsd',
+  'group' => '_statsd',
+  'version' => '0.7.2-8',
+  'repo' => {
+    'package_cloud_user' => 'till',
+    'package_cloud_repo' => 'ies-statsd'
+  }
 }

--- a/statsd/recipes/configure.rb
+++ b/statsd/recipes/configure.rb
@@ -1,21 +1,24 @@
+include_recipe 'statsd::service'
+
 base = node['librato']['statsd']['etc_dir']
 
 directory base do
   mode  '0755'
-  owner node['librato']['statsd']['user']
-  group node['librato']['statsd']['group']
+  owner node['statsd']['user']
+  group node['statsd']['group']
 end
 
 cluster_name = get_cluster_name.gsub(/\s+/, '-')
 
-template "#{base}/config.js" do
+template "#{base}/localConfig.js" do
   source 'easybib-config.js.erb'
   mode   '0600'
-  owner  node['librato']['statsd']['user']
-  group  node['librato']['statsd']['group']
+  owner  node['statsd']['user']
+  group  node['statsd']['group']
   variables(
     :statsd => node['librato']['statsd'],
     :metrics => node['librato']['metrics'],
     :cluster_name => cluster_name
   )
+  notifies :start, 'service[statsd]'
 end

--- a/statsd/recipes/default.rb
+++ b/statsd/recipes/default.rb
@@ -1,32 +1,22 @@
-Chef::Resource.send(:include, EasyBib)
+# temporary until we have time to import the packagecloud cookbook
+repo_user = node['statsd']['repo']['package_cloud_user']
+repo_name = node['statsd']['repo']['package_cloud_repo']
+repo_file = "/etc/apt/sources.list.d/#{repo_user}_#{repo_name}.list"
 
-group node['statsd']['group'] do
-  action :create
+remote_file "#{Chef::Config[:file_cache_path]}/install-package_cloud.sh" do
+  source "https://packagecloud.io/install/repositories/#{repo_user}/#{repo_name}/script.deb.sh"
+  mode 0755
+  not_if { ::File.exist?(repo_file) }
 end
 
-user node['statsd']['user'] do
-  home node['statsd']['deploy_dir']
-  manage_home true
-  group node['statsd']['group']
-  shell '/bin/false'
-  system true
-  action :create
+execute 'run-package_cloud.sh' do
+  command "#{Chef::Config[:file_cache_path]}/install-package_cloud.sh"
+  not_if { ::File.exist?(repo_file) }
 end
 
-target_dir = "#{node['statsd']['deploy_dir']}/#{node['statsd']['branch']}"
-
-nodejs_npm 'install deps' do
-  path target_dir
-  user node['statsd']['user']
-  group node['statsd']['group']
-  action :nothing
+package 'statsd' do
+  action :install
+  version node['statsd']['version']
 end
 
-git target_dir do
-  repository node['statsd']['repository']
-  revision node['statsd']['branch']
-  user node['statsd']['user']
-  group node['statsd']['group']
-  not_if { is_aws }
-  notifies :install, 'nodejs_npm[install deps]'
-end
+include_recipe 'statsd::configure'

--- a/statsd/recipes/default.rb
+++ b/statsd/recipes/default.rb
@@ -27,6 +27,6 @@ git target_dir do
   revision node['statsd']['branch']
   user node['statsd']['user']
   group node['statsd']['group']
-  not_if is_aws
+  not_if { is_aws }
   notifies :install, 'nodejs_npm[install deps]'
 end

--- a/statsd/recipes/service.rb
+++ b/statsd/recipes/service.rb
@@ -1,0 +1,4 @@
+service 'statsd' do
+  provider Chef::Provider::Service::Upstart
+  supports [:start, :enable, :stop, :status]
+end

--- a/statsd/recipes/user.rb
+++ b/statsd/recipes/user.rb
@@ -1,0 +1,13 @@
+# replace this with postinst
+group node['statsd']['group'] do
+  action :create
+end
+
+user node['statsd']['user'] do
+  home '/nonexistent'
+  manage_home false
+  group node['statsd']['group']
+  shell '/bin/false'
+  system true
+  action :create
+end

--- a/statsd/spec/configure_spec.rb
+++ b/statsd/spec/configure_spec.rb
@@ -2,21 +2,24 @@ require 'chefspec'
 
 describe 'statsd::configure' do
 
+  let(:stack_name) { 'chef spec run' }
+
   let(:chef_run) do
     ChefSpec::Runner.new do |node|
       # fake opsworks
       node.default['opsworks'] = {}
       node.default.opsworks['stack'] = {}
-      node.default.opsworks.stack['name'] = 'chef spec run'
+      node.default.opsworks.stack['name'] = stack_name
     end.converge(described_recipe)
   end
 
-  it 'creates /etc/statsd/config.js' do
-    expect(chef_run).to render_file('/etc/statsd/config.js')
+  let(:config) { '/etc/statsd/localConfig.js' }
+
+  it 'creates the config' do
+    expect(chef_run).to render_file(config)
   end
 
   it 'it contains the correct settings' do
-
     # before you think twice - this is javascript, not JSON
     conf  = "{\n"
     conf << "  port: 8125,\n"
@@ -25,11 +28,11 @@ describe 'statsd::configure' do
     conf << "  librato: {\n"
     conf << "    email: 'foo@example.org',\n"
     conf << "    token: '123',\n"
-    conf << "    source: 'chef-spec-run',\n"
+    conf << "    source: '#{stack_name.gsub!(' ', '-')}',\n"
     conf << "    batchSize: 200\n"
     conf << "  }\n"
     conf << "}\n"
 
-    expect(chef_run).to render_file('/etc/statsd/config.js').with_content(conf)
+    expect(chef_run).to render_file(config).with_content(conf)
   end
 end


### PR DESCRIPTION
Next iteration, in the never ending quest to fix statsd deployments! Now with a test!

:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :trollface:
:trollface: :trollface: :trollface: :rocket:

Changes:

 * unified way to setup statsd (locally and in production)
 * moved config file to match Debian package
 * changed user/group to match Debian package (now: `_statsd`)
 * removed OpsWorks app integration in favour of a Debian package (via package cloud)
 * moved to upstart and no longer using monit 
 * also this: https://github.com/till/easybib-cookbooks/commit/b4dd2f750584af7d809b29cccb411e793431feef

Related: easybib/issues#4353