### PR TITLE
Fix: Use separate monitoring credentials

### DIFF
--- a/apache-couchdb/attributes/default.rb
+++ b/apache-couchdb/attributes/default.rb
@@ -29,3 +29,8 @@ default['apache-couchdb']['fauxton'] = {
   'repository' => 'https://github.com/apache/couchdb-fauxton.git',
   'version' => 'b61f60181ccc9d728bde5e6ad7ebbec4a4bd7b20'
 }
+
+default['apache-couchdb']['monitoring'] = {
+  'user' => '',
+  'pass' => ''
+}

--- a/apache-couchdb/recipes/monitoring.rb
+++ b/apache-couchdb/recipes/monitoring.rb
@@ -2,11 +2,9 @@ Chef::Resource.send(:include, EasyBib)
 
 bin_path = '/usr/local/bin/check_couchdb'
 
-# this is an assumption for what is to follow!
-monitoring_user = 'monitoring'
-
-unless node['apache-couchdb']['config'].fetch('admins', {})[monitoring_user].nil?
-  monitoring_pass = node['apache-couchdb']['config']['admins'][monitoring_user]
+unless node['apache-couchdb']['monitoring']['user'].empty?
+  monitoring_user = node['apache-couchdb']['monitoring']['user']
+  monitoring_pass = node['apache-couchdb']['monitoring']['pass']
   credentials = "#{monitoring_user}:#{monitoring_pass}"
 
   template bin_path do

--- a/apache-couchdb/spec/monitoring_spec.rb
+++ b/apache-couchdb/spec/monitoring_spec.rb
@@ -24,8 +24,9 @@ describe 'apache-couchdb::configure' do
 
   describe 'setup monitoring' do
     before do
-      node.set['apache-couchdb']['config']['admins'] = {
-        'monitoring' => 'test123'
+      node.set['apache-couchdb']['monitoring'] = {
+        'user' => 'monitoring',
+        'pass' => 'test123'
       }
     end
 


### PR DESCRIPTION
Since we are now encrypting the credentials in stack json, we can not use those for the monitoring user anymore since we need clear-text passwords in that case. This PR fetches the unencrypted monitoring user credentials from a new `node['apache-couchdb']['monitoring']`setting.

Fixes: https://imagineeasy.atlassian.net/browse/DEVOPS-40