### PR TITLE
Introduce: ies::role-configure

### DIFF
--- a/ies/recipes/role-configure.rb
+++ b/ies/recipes/role-configure.rb
@@ -1,0 +1,1 @@
+include_recipe 'ies-route53::add'


### PR DESCRIPTION
Issue: easybib/issues#5085

---- 

- call ies-route53::add from ies::role-configure
  this promises to catch EIP changes and reflect them in our
  infrastructure DNS.