### PR TITLE
Extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ fc_sandbox
 .kitchen.local.yml
 easybib-cookbooks.tar.gz
 *.pyc
+.idea/*
+.todo


### PR DESCRIPTION
- .idea/ is the default for IntelliJ based IDEs, including RubyMine (which I am using)
- .todo is the default file used by the CLI tool `devtodo`.