### PR TITLE
Bugfix: php-mysqli is part of core, needs only config

### DIFF
--- a/php/recipes/module-mysqli.rb
+++ b/php/recipes/module-mysqli.rb
@@ -1,7 +1,14 @@
 include_recipe 'php::dependencies-ppa'
 
 module_config = node['php-mysqli']['settings']
+package_name = node['php']['ppa']['package_prefix']
 
-php_ppa_package 'mysqli' do
+package package_name do
+  action :install
+  notifies :reload, 'service[php-fpm]', :delayed
+end
+
+php_config 'mysqli' do
   config module_config
+  notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/spec/module-mysqli_spec.rb
+++ b/php/spec/module-mysqli_spec.rb
@@ -6,12 +6,20 @@ describe 'php::module-mysqli' do
   let(:chef_run)  { runner.converge(described_recipe) }
   let(:node)      { runner.node }
 
+  before do
+    node.override['php']['ppa']['package_prefix'] = 'php-ppa-prefix'
+  end
+
   it 'adds ppa mirror configuration' do
     expect(chef_run).to include_recipe('php::dependencies-ppa')
   end
 
-  it 'installs and configures the extension' do
-    expect(chef_run).to install_php_ppa_package('mysqli')
+  it 'installs the core php package' do
+    expect(chef_run).to install_package('php-ppa-prefix')
+  end
+
+  it 'configures the extension' do
+    expect(chef_run).to generate_php_config('mysqli')
       .with(:config => node['php-mysqli']['settings'])
   end
 end


### PR DESCRIPTION
regression from DEVOPS-18: There is no dedicated `php5-easybib-mysqli`, we only configure/enable it