### PR TITLE
Remove deprecated sitescraper when-clause

### DIFF
--- a/nginx-app/recipes/configure.rb
+++ b/nginx-app/recipes/configure.rb
@@ -24,9 +24,6 @@ node['deploy'].each do |application, deploy|
   when 'easybib_api'
     next unless allow_deploy(application, 'easybib_api', 'bibapi')
 
-  when 'sitescraper'
-    next unless allow_deploy(application, 'sitescraper')
-
   when 'research_app'
     next unless allow_deploy(application, 'research_app', 'research_app')
 


### PR DESCRIPTION
There is a bug in our current master affecting all instances in `sitescraper` layers. A deprecated `where`-clause hasn't been removed from the `nginx-app::configure` recipe in one of our recent refactorings.