### PR TITLE
nginx cannot handle high speed UDP logging ATM

### DIFF
--- a/nginx-app/attributes/default.rb
+++ b/nginx-app/attributes/default.rb
@@ -10,7 +10,8 @@ default['nginx-app']['ppa'] = 'ppa:nginx/stable'
 default['nginx-app']['client_max_body_size'] = '5m'
 
 default['nginx-app']['error_log'] = 'syslog:server=unix:/dev/log error'
-default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232'
+#default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232'
+default['nginx-app']['access_log'] = 'off'
 
 default['nginx-app']['extras'] = ''
 

--- a/nginx-app/attributes/default.rb
+++ b/nginx-app/attributes/default.rb
@@ -10,7 +10,7 @@ default['nginx-app']['ppa'] = 'ppa:nginx/stable'
 default['nginx-app']['client_max_body_size'] = '5m'
 
 default['nginx-app']['error_log'] = 'syslog:server=unix:/dev/log error'
-#default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232'
+# default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232'
 default['nginx-app']['access_log'] = 'off'
 
 default['nginx-app']['extras'] = ''


### PR DESCRIPTION
Changing default access_log from:

    default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232'

to:

    default['nginx-app']['access_log'] = 'off'

I am leaving default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232' commented out in the default.rb file as a reference.

This will result in the /etc/nginx/sites-enabled/easybib.conf having :

    access_log off;

instead of :

    access_log syslog:server=127.0.0.1:23232;

This change was necessitated by similar errors to this in syslog:

```
send() to syslog failed while logging request,
   client: 10.16.230.125,
   server: opsworks.playground.easybib.com,
   request: "GET /health_check.php HTTP/1.0",
   upstream: "fastcgi://unix:/var/run/php-fpm/pool1"
```

Basically, this issue manifested in many "connection refused" errors.

