### PR TITLE
DEVOPS-71 - revert to original configuration

### DIFF
--- a/nginx-app/attributes/default.rb
+++ b/nginx-app/attributes/default.rb
@@ -10,8 +10,8 @@ default['nginx-app']['ppa'] = 'ppa:nginx/stable'
 default['nginx-app']['key'] = 'C300EE8C.key'
 default['nginx-app']['client_max_body_size'] = '5m'
 
-default['nginx-app']['error_log'] = 'syslog:server=unix:/dev/log error'
-default['nginx-app']['access_log'] = 'syslog:server=127.0.0.1:23232'
+default['nginx-app']['error_log'] = '/var/log/nginx/error.log error'
+default['nginx-app']['access_log'] = 'off'
 
 default['nginx-app']['extras'] = ''
 


### PR DESCRIPTION
https://imagineeasy.atlassian.net/browse/DEVOPS-71

Revert of all logging attempts:

Since I could not find an acceptable solution in the time frame allowed;
  1. nginx uses udp correctly and expects a registered udp listener or will error with connection refused,
  2. nginx can log to a fifo but can not be configured as a circular fifo so will error as soon as buffer is full
  3. using rsyslog as a udp reflector in the same way that I found haproxy to log was deemed unacceptable because it engaged too much legacy code or actions to clean up.
