### PR TITLE
Streamline: nginx_local_conf is no longer a parameter

### DIFF
--- a/easybib-deploy/recipes/scholar.rb
+++ b/easybib-deploy/recipes/scholar.rb
@@ -41,7 +41,6 @@ node['deploy'].each do |application, deploy|
     domain_name deploy['domains'].join(' ')
     doc_root deploy['document_root']
     htpasswd "#{deploy['deploy_to']}/current/htpasswd"
-    nginx_local_conf "#{::EasyBib::Config.get_appdata(node, application, 'app_dir')}/deploy/nginx.conf"
     listen_opts listen_opts
     notifies :reload, 'service[nginx]', :delayed
     notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed

--- a/easybib/providers/nginx.rb
+++ b/easybib/providers/nginx.rb
@@ -28,8 +28,6 @@ action :setup do
   nginx_extras = get_nginx_extras(new_resource, node)
   cache_config = get_cache_config(new_resource, node)
 
-  nginx_local_conf = get_local_conf(new_resource)
-
   htpasswd = get_htpasswd(new_resource, application)
 
   health_check = get_health_check(application, node)
@@ -37,6 +35,8 @@ action :setup do
   routes_denied  =  get_routes(application, node, 'routes_denied')
 
   default_router = get_default_router(node['nginx-app']['default_router'], new_resource.default_router, deploy_dir)
+
+  nginx_local_conf = get_local_conf("#{app_dir}/deploy/nginx.conf")
 
   execute_name = "nginx_configtest_#{config_name}"
   execute execute_name do
@@ -80,12 +80,8 @@ action :setup do
 
 end
 
-def get_local_conf(new_resource)
-  unless new_resource.nginx_local_conf.nil?
-    if ::File.exist?(new_resource.nginx_local_conf)
-      return new_resource.nginx_local_conf
-    end
-  end
+def get_local_conf(nginx_local_conf)
+  return nginx_local_conf if ::File.exist?(nginx_local_conf)
   nil
 end
 

--- a/easybib/resources/nginx.rb
+++ b/easybib/resources/nginx.rb
@@ -9,7 +9,6 @@ attribute :doc_root, :kind_of => String, :default => 'www'
 attribute :access_log, :kind_of => String, :default => 'off'
 attribute :domain_name, :kind_of => String, :default => nil
 attribute :nginx_extras, :kind_of => String, :default => nil
-attribute :nginx_local_conf, :kind_of => String, :default => nil
 attribute :htpasswd, :kind_of => String, :default => nil
 attribute :deploy_dir, :kind_of => String, :default => nil
 attribute :app_dir, :kind_of => String, :default => nil

--- a/nginx-app/recipes/vagrant-silex.rb
+++ b/nginx-app/recipes/vagrant-silex.rb
@@ -28,7 +28,6 @@ node['vagrant']['applications'].each do |app_name, app_config|
     deploy_dir doc_root_location
     default_router default_router
     domain_name domain_name
-    nginx_local_conf "#{app_dir}/deploy/nginx.conf"
     notifies :reload, 'service[nginx]', :delayed
   end
 

--- a/nginx-app/recipes/vagrant.rb
+++ b/nginx-app/recipes/vagrant.rb
@@ -27,8 +27,7 @@ template '/etc/nginx/sites-enabled/easybib.com.conf' do
     :upstream_name => 'www',
     :environment  => get_cluster_name(node),
     :doc_root     => get_appdata(node, 'www', 'doc_root_dir'),
-    :app_dir      => app_dir,
-    :nginx_local_conf => "#{app_dir}/deploy/nginx.conf"
+    :app_dir      => app_dir
   )
   notifies :reload, 'service[nginx]', :delayed
 end

--- a/stack-academy/recipes/deploy.rb
+++ b/stack-academy/recipes/deploy.rb
@@ -31,7 +31,6 @@ node['deploy'].each do |application, deploy|
     domain_name deploy['domains'].join(' ')
     doc_root deploy['document_root']
     htpasswd "#{deploy['deploy_to']}/current/htpasswd"
-    nginx_local_conf "#{::EasyBib::Config.get_appdata(node, application, 'app_dir')}/deploy/nginx.conf"
     notifies :reload, 'service[nginx]', :delayed
     notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end

--- a/stack-citationapi/recipes/deploy-vagrant.rb
+++ b/stack-citationapi/recipes/deploy-vagrant.rb
@@ -17,7 +17,6 @@ node['vagrant']['applications'].each do |app_name, app_config|
     deploy_dir doc_root_location
     default_router default_router
     domain_name domain_name
-    nginx_local_conf "#{app_dir}/deploy/nginx.conf"
     notifies :reload, 'service[nginx]', :delayed
   end
 

--- a/stack-test/recipes/deploy.rb
+++ b/stack-test/recipes/deploy.rb
@@ -24,7 +24,6 @@ node['deploy'].each do |application, deploy|
     config_template config_template
     domain_name deploy['domains'].join(' ')
     doc_root deploy['document_root']
-    nginx_local_conf "#{::EasyBib::Config.get_appdata(node, application, 'app_dir')}/deploy/nginx.conf"
     listen_opts nil
     notifies :reload, 'service[nginx]', :delayed
     notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed


### PR DESCRIPTION
* if set, it is set to `deploy/nginx.conf` everywhere
* now acts like the other files in `deploy/`- if file is there, it is used