### PR TITLE
Fix: ies::opsworks-fixes breaks EBS volumes

### DIFF
--- a/ies/recipes/opsworks-fixes.rb
+++ b/ies/recipes/opsworks-fixes.rb
@@ -15,33 +15,24 @@ end
 
 # ensures mounting of all devices:
 # - https://imagineeasy.atlassian.net/browse/DEVOPS-77
-if is_aws
+if is_aws && File.exist?('/dev/xvdc')
   directory '/mnt2' do
     owner 'root'
     group 'root'
     mode '0755'
     action :create
-    only_if do
-      File.exist?('/dev/xvdc')
-    end
   end
   execute 'format xvdc if required' do
     # AWS auto-formats its volumes with ext3. We want ext4 for performance
     # reasons. If we find an ext3 formatted xvdc device, we assume that the
     # volume is "new" (as in: has no data yet) and format it with ext4.
     command '(([[ -a /dev/xvdc ]] && file -sL /dev/xvdc | grep "\<ext3\>") && mkfs.ext4 /dev/xvdc) || true'
-    only_if do
-      File.exist?('/dev/xvdc')
-    end
   end
   template '/etc/fstab' do
     source 'fstab'
     owner 'root'
     group 'root'
     mode '0644'
-    only_if do
-      File.exist?('/dev/xvdc')
-    end
   end
   execute 'mount all' do
     command 'mount -a'


### PR DESCRIPTION
The current implementation always overwrites fstab ignoring any local differences, which blows up any instance with EBS volumes mounted