### PR TITLE
Refactor: decouple php_ppa_package & php_config

### DIFF
--- a/php/providers/ppa_package.rb
+++ b/php/providers/ppa_package.rb
@@ -11,15 +11,6 @@ action :install do
     action :install
     notifies :reload, 'service[php-fpm]', :delayed
   end
-  updated = p.updated_by_last_action?
 
-  unless new_resource.config.nil?
-    c = php_config name do
-      config new_resource.config
-      notifies :reload, 'service[php-fpm]', :delayed
-    end
-    updated ||= c.updated_by_last_action?
-  end
-
-  new_resource.updated_by_last_action(updated)
+  new_resource.updated_by_last_action(p.updated_by_last_action?)
 end

--- a/php/recipes/module-apc.rb
+++ b/php/recipes/module-apc.rb
@@ -9,6 +9,10 @@ if is_aws
 end
 
 php_ppa_package 'apc' do
-  config apc_attributes
   package_name 'apcu'
+end
+
+php_config 'apc' do
+  config apc_attributes
+  notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/recipes/module-opcache.rb
+++ b/php/recipes/module-opcache.rb
@@ -2,8 +2,11 @@ include_recipe 'php::dependencies-ppa'
 
 module_config = node['php-opcache']['settings']
 
-php_ppa_package 'opcache' do
+php_ppa_package 'opcache'
+
+php_config 'opcache' do
   config module_config
+  notifies :reload, 'service[php-fpm]', :delayed
 end
 
 file 'create opcache error_log' do

--- a/php/recipes/module-phar.rb
+++ b/php/recipes/module-phar.rb
@@ -2,6 +2,9 @@ include_recipe 'php::dependencies-ppa'
 
 module_config = node['php-phar']['settings']
 
-php_ppa_package 'phar' do
+php_ppa_package 'phar'
+
+php_config 'phar' do
   config module_config
+  notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/recipes/module-xdebug.rb
+++ b/php/recipes/module-xdebug.rb
@@ -2,6 +2,9 @@ include_recipe 'php::dependencies-ppa'
 
 module_config = node['php-xdebug']['settings']
 
-php_ppa_package 'xdebug' do
+php_ppa_package 'xdebug'
+
+php_config 'xdebug' do
   config module_config
+  notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/resources/ppa_package.rb
+++ b/php/resources/ppa_package.rb
@@ -2,5 +2,4 @@ actions :install
 default_action :install
 
 attribute :name, :kind_of => String, :named_attribute => true
-attribute :config, :kind_of => Hash, :default => nil
 attribute :package_name, :kind_of => String, :default => nil

--- a/php/spec/fixtures/recipes/php-ppa_package.rb
+++ b/php/spec/fixtures/recipes/php-ppa_package.rb
@@ -1,6 +1,10 @@
 include_recipe 'php-fpm::service'
 
 php_ppa_package node['ppa_package-spec']['name'] do
-  config node['ppa_package-spec']['config']
   package_name node['ppa_package-spec']['packagename']
+end
+
+php_config node['ppa_package-spec']['name'] do
+  config node['ppa_package-spec']['config']
+  notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/spec/module-opcache_spec.rb
+++ b/php/spec/module-opcache_spec.rb
@@ -20,7 +20,9 @@ describe 'php::module-opcache' do
 
     it 'installs and configures the extension' do
       expect(chef_run).to install_php_ppa_package('opcache')
-        .with(:config =>  node['php-opcache']['settings'])
+
+      expect(chef_run).to generate_php_config('opcache')
+        .with(:config => node['php-opcache']['settings'])
     end
 
     it 'creates the logfile with correct permission' do

--- a/php/spec/module-phar_spec.rb
+++ b/php/spec/module-phar_spec.rb
@@ -12,6 +12,7 @@ describe 'php::module-phar' do
 
   it 'installs and configures the extension' do
     expect(chef_run).to install_php_ppa_package('phar')
+    expect(chef_run).to generate_php_config('phar')
       .with(:config => node['php-phar']['settings'])
   end
 end

--- a/php/spec/module-xdebug_spec.rb
+++ b/php/spec/module-xdebug_spec.rb
@@ -12,6 +12,7 @@ describe 'php::module-xdebug' do
 
   it 'installs and configures the extension' do
     expect(chef_run).to install_php_ppa_package('xdebug')
+    expect(chef_run).to generate_php_config('xdebug')
       .with(:config => node['php-xdebug']['settings'])
   end
 end


### PR DESCRIPTION
This PR decouples `php_ppa_package` & `php_config` so we can control what is done with `php_config` directly vs. adding more flags to `php_ppa_package` or accessing `node[]` from within it.

Makes recipes slightly more verbose, but hopefully easier to understand.

Related: DEVOPS-124