### PR TITLE
Refactor: allow override of file path settings

### DIFF
--- a/php/attributes/default.rb
+++ b/php/attributes/default.rb
@@ -2,6 +2,9 @@ default['php']['ppa']['name'] = 'easybib-ppa'
 default['php']['ppa']['uri'] = ::EasyBib::Ppa.ppa_mirror(node)
 default['php']['ppa']['package_prefix'] = 'php5-easybib'
 
+default['php']['extensions']['config_dir'] = 'etc/php'
+default['php']['extensions']['ini_suffix'] = '-settings'
+
 default['php-apc'] = {}
 default['php-apc']['settings']['ttl'] = 0
 default['php-apc']['settings']['mmap_file_mask'] = '/dev/zero'

--- a/php/providers/config.rb
+++ b/php/providers/config.rb
@@ -1,5 +1,12 @@
 action :generate do
-  file = "#{new_resource.prefix_dir}/etc/php/#{new_resource.name}-settings.ini"
+  file = format(
+    '%{prefix}/%{config_dir}/%{ext_name}%{ini_suffix}.ini',
+    :prefix => new_resource.prefix_dir,
+    :config_dir => new_resource.config_dir,
+    :ext_name => new_resource.name,
+    :ini_suffix => new_resource.suffix
+  )
+
   config = ::Php::Config.new(new_resource.name, new_resource.config)
   extension = {}
 

--- a/php/recipes/module-apc.rb
+++ b/php/recipes/module-apc.rb
@@ -14,5 +14,7 @@ end
 
 php_config 'apc' do
   config apc_attributes
+  config_dir node['php']['extensions']['config_dir']
+  suffix node['php']['extensions']['ini_suffix']
   notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/recipes/module-mysqli.rb
+++ b/php/recipes/module-mysqli.rb
@@ -10,5 +10,7 @@ end
 
 php_config 'mysqli' do
   config module_config
+  config_dir node['php']['extensions']['config_dir']
+  suffix node['php']['extensions']['ini_suffix']
   notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/recipes/module-opcache.rb
+++ b/php/recipes/module-opcache.rb
@@ -6,6 +6,8 @@ php_ppa_package 'opcache'
 
 php_config 'opcache' do
   config module_config
+  config_dir node['php']['extensions']['config_dir']
+  suffix node['php']['extensions']['ini_suffix']
   notifies :reload, 'service[php-fpm]', :delayed
 end
 

--- a/php/recipes/module-phar.rb
+++ b/php/recipes/module-phar.rb
@@ -6,5 +6,7 @@ php_ppa_package 'phar'
 
 php_config 'phar' do
   config module_config
+  config_dir node['php']['extensions']['config_dir']
+  suffix node['php']['extensions']['ini_suffix']
   notifies :reload, 'service[php-fpm]', :delayed
 end

--- a/php/resources/config.rb
+++ b/php/resources/config.rb
@@ -8,6 +8,8 @@ end
 
 attribute :name, :kind_of => String, :named_attribute => true
 attribute :prefix_dir, :kind_of => String
+attribute :config_dir, :kind_of => String, :default => 'etc/php'
+attribute :suffix, :kind_of => String, :default => '-settings'
 attribute :config, :kind_of => Hash
 attribute :extension_path, :kind_of => String, :default => nil
 attribute :load_extension, :kind_of => [TrueClass, FalseClass], :default => false

--- a/php/spec/fixtures/recipes/php-config.rb
+++ b/php/spec/fixtures/recipes/php-config.rb
@@ -2,6 +2,8 @@ php_config node['config-spec']['name'] do
   config node['config-spec']['config']
   prefix_dir node['config-spec']['prefix_dir']
   extension_path node['config-spec']['extension_path']
+  config_dir node['config-spec']['config_dir']
+  suffix node['config-spec']['ini_suffix']
   load_extension node['config-spec']['load_extension']
   zend_extension node['config-spec']['zend_extension']
 end

--- a/php/spec/provider-config_spec.rb
+++ b/php/spec/provider-config_spec.rb
@@ -110,4 +110,15 @@ describe 'php_config' do
         .with_content(fixture)
     end
   end
+
+  describe 'another path' do
+    before do
+      node.set['config-spec']['config_dir'] = 'etc/php/5.6/conf.d'
+      node.set['config-spec']['ini_suffix'] = ''
+    end
+
+    it 'creates a .ini file' do
+      expect(chef_run).to render_file('/prefix/dir/etc/php/5.6/conf.d/modulename.ini')
+    end
+  end
 end


### PR DESCRIPTION
Make path and suffix attributes to the provider and supply them with default attributes so we don't break the status quo.

Related: DEVOPS-124