### PR TITLE
Fix: Remove errorneous config path

### DIFF
--- a/php/recipes/module-tidy.rb
+++ b/php/recipes/module-tidy.rb
@@ -1,6 +1,5 @@
 include_recipe 'php::dependencies-ppa'
 
-node.override['php-tidy']['settings']['default_config'] = "#{node['php-fpm']['tmpdir']}/lib/php/default.tcfg"
 module_config = node['php-tidy']['settings']
 
 php_ppa_package 'tidy' do


### PR DESCRIPTION
This used to be disabled in the old config: https://github.com/till/easybib-cookbooks/blob/80c8a05cc7adbc7fa1f57522571f0d457788ae1a/php-fpm/templates/default/php.ini.erb#L132 and points to a nonexisting file