### PR TITLE
Ability to disable logging of 404 in stack-easybib

### DIFF
--- a/stack-easybib/attributes/default.rb
+++ b/stack-easybib/attributes/default.rb
@@ -24,3 +24,5 @@ normal['nginx-app']['browser_caching']['config']['css|svg|map|js'] = {
     'Vary "Accept-Encoding"'
   ]
 }
+
+default['easybib']['nginx-app']['disable-404'] = false

--- a/stack-easybib/recipes/deploy-easybib.rb
+++ b/stack-easybib/recipes/deploy-easybib.rb
@@ -21,9 +21,16 @@ node['deploy'].each do |application, deploy|
     ignore_failure true
   end
 
+  nginx_extras = if node.fetch('easybib', {}).fetch('nginx-app', {}).fetch('disable-404', {})
+                   'log_not_found off;'
+                 else
+                   ''
+                 end
+
   easybib_nginx application do
     cookbook 'stack-easybib'
     config_template 'easybib.com.conf.erb'
+    nginx_extras nginx_extras
     notifies :reload, 'service[nginx]', :delayed
     notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end


### PR DESCRIPTION
This PR introduces the ability to disable logging of 404 errors in the nginx error-log.
- Node: node['easybib']['nginx-app']['disable-404']
- Type: bool
- Default: false