### PR TITLE
set pcre recursion limit

### DIFF
--- a/php-fpm/templates/default/php.ini.erb
+++ b/php-fpm/templates/default/php.ini.erb
@@ -62,6 +62,7 @@ max_file_uploads = 20
 allow_url_fopen = On
 allow_url_include = Off
 default_socket_timeout = 60
+pcre.recursion_limit = 10000
 
 [Date]
 date.timezone = America/New_York


### PR DESCRIPTION
number is arbitrary, but lower than the default (100k) - tested on the easybib VM and seems to help