### PR TITLE
Add of local config support for easybib stack template

### DIFF
--- a/stack-easybib/templates/default/easybib.com.conf.erb
+++ b/stack-easybib/templates/default/easybib.com.conf.erb
@@ -82,6 +82,10 @@ unless uncached_extensions.empty? -%>
   %>
 <% end -%>
 
+<% unless @nginx_local_conf.nil? -%>
+<%= render @nginx_local_conf, :local => true %>
+<% end -%>
+
 <%
 @environment = EasyBib.get_cluster_name(node)
 %>


### PR DESCRIPTION
When I was working on a solution for https://github.com/easybib/sbm-issues/issues/359 I added a /deploy/nginx.conf and found that it was not added to the nginx/sites-enabled/[appname].conf template.  This is a quick fix to add that rendering.