### PR TITLE
Fix: Variable name collision

### DIFF
--- a/easybib/providers/nginx.rb
+++ b/easybib/providers/nginx.rb
@@ -27,7 +27,7 @@ action :setup do
   app_dir = get_app_dir(new_resource, node)
   config_name = get_config_name(new_resource)
   nginx_extras = get_nginx_extras(new_resource, node)
-  cache_config = get_cache_config(new_resource, node)
+  nginx_caching = get_nginx_caching(new_resource, node)
 
   htpasswd = get_htpasswd(new_resource, application)
 
@@ -68,7 +68,7 @@ action :setup do
       :routes_denied => routes_denied,
       :htpasswd => htpasswd,
       :listen_opts => listen_opts,
-      :cache_config => cache_config,
+      :nginx_caching => nginx_caching,
       :gzip => node['nginx-app']['gzip']
     )
     notifies :run, "execute[#{execute_name}]", :immediately
@@ -121,9 +121,10 @@ def get_domain_name(new_resource, node)
   ::EasyBib::Config.get_domains(node, new_resource.app_name)
 end
 
-def get_cache_config(new_resource, node)
-  return new_resource.cache_config unless new_resource.cache_config.nil?
-  node['nginx-app']['browser_caching']
+# nginx caching - this does not deal with browser cache headers
+def get_nginx_caching(new_resource, node)
+  return new_resource.nginx_caching unless new_resource.nginx_caching.nil?
+  node['nginx-app']['cache']
 end
 
 def get_nginx_extras(new_resource, node)

--- a/easybib/resources/nginx.rb
+++ b/easybib/resources/nginx.rb
@@ -14,5 +14,5 @@ attribute :deploy_dir, :kind_of => String, :default => nil
 attribute :app_dir, :kind_of => String, :default => nil
 attribute :default_router, :kind_of => String, :default => nil
 attribute :listen_opts, :kind_of => String, :default => nil
-attribute :cache_config, :kind_of => Hash, :default => nil
+attribute :nginx_caching, :kind_of => Hash, :default => nil
 attribute :cookbook, :kind_of => String, :default => 'nginx-app'

--- a/nginx-app/attributes/default.rb
+++ b/nginx-app/attributes/default.rb
@@ -61,7 +61,7 @@ default['nginx-app']['css_modules'] = {
   'folders'         => 'folders'
 }
 
-default['nginx-app']['browser_caching'] = {
+default['nginx-app']['nginx_caching'] = {
   'enabled' => false,
   'lifetime' => '5m',
   'methods' => 'GET',

--- a/nginx-app/templates/default/partials/php-routes-default.erb
+++ b/nginx-app/templates/default/partials/php-routes-default.erb
@@ -32,8 +32,8 @@
 
         add_header X-Cache $upstream_cache_status;
 
-<% if @cache_config and @cache_config["enabled"] == true -%>
-        fastcgi_cache <%=@cache_config["zone"]%>;
+<% if @nginx_caching and @nginx_caching["enabled"] == true -%>
+        fastcgi_cache <%=@nginx_caching["zone"]%>;
         fastcgi_cache_bypass $fastcgi_skipcache;
         fastcgi_no_cache $fastcgi_skipcache;
 <% end -%>

--- a/nginx-app/templates/default/scholar.conf.erb
+++ b/nginx-app/templates/default/scholar.conf.erb
@@ -113,8 +113,8 @@ server {
 
         add_header X-Cache $upstream_cache_status;
 
-<% if @cache_config and @cache_config["enabled"] == true -%>
-        fastcgi_cache <%=@cache_config["zone"]%>;
+<% if @nginx_caching and @nginx_caching["enabled"] == true -%>
+        fastcgi_cache <%=@nginx_caching["zone"]%>;
         fastcgi_cache_bypass $fastcgi_skipcache;
         fastcgi_no_cache $fastcgi_skipcache;
 <% end -%>

--- a/nginx-app/templates/default/silex.conf.erb
+++ b/nginx-app/templates/default/silex.conf.erb
@@ -51,7 +51,7 @@ server {
         "access_log" => @access_log,
         "default_router" => @default_router,
         "node" => @node,
-        "cache_config" => @cache_config
+        "nginx_caching" => @nginx_caching
     } %>
     <% else -%>
 <%= render "partials/php-routes-specific-routes.erb", :cookbook => 'nginx-app', :variables => {

--- a/nginx-app/tests/test_helpers.rb
+++ b/nginx-app/tests/test_helpers.rb
@@ -35,7 +35,7 @@ class TestHelpers < Test::Unit::TestCase
   end
 
   def test_uncached_static_extensions
-    cache_config = {
+    browser_cache_config = {
       'enabled' => false,
       'config' => {
         'eot|ttf|woff' => {
@@ -48,16 +48,16 @@ class TestHelpers < Test::Unit::TestCase
     result = ::NginxApp::Helpers.uncached_static_extensions(nil)
     assert_equal(%w(jpg jpeg gif png css js ico woff ttf eot), result)
 
-    result = ::NginxApp::Helpers.uncached_static_extensions(cache_config)
+    result = ::NginxApp::Helpers.uncached_static_extensions(browser_cache_config)
     assert_equal(%w(jpg jpeg gif png css js ico woff ttf eot), result)
 
-    cache_config['enabled'] = true
-    result = ::NginxApp::Helpers.uncached_static_extensions(cache_config)
+    browser_cache_config['enabled'] = true
+    result = ::NginxApp::Helpers.uncached_static_extensions(browser_cache_config)
     assert_equal(%w(jpg jpeg gif png css ico), result)
 
     # test for devops-151: make sure we are able to deal with ImmutableMash input
     config = Chef::Node::ImmutableMash.new('list' => %w(eot jpg))
-    result = ::NginxApp::Helpers.uncached_static_extensions(cache_config, config['list'])
+    result = ::NginxApp::Helpers.uncached_static_extensions(browser_cache_config, config['list'])
     assert_equal(%w(jpg), result)
   end
 end

--- a/stack-citationapi/templates/default/default-web-nginx.conf.erb
+++ b/stack-citationapi/templates/default/default-web-nginx.conf.erb
@@ -47,7 +47,7 @@ server {
         "access_log" => @access_log,
         "default_router" => @default_router,
         "node" => @node,
-        "cache_config" => @cache_config
+        "nginx_caching" => @nginx_caching
     } %>
     <% else -%>
 <%= render "partials/php-routes-specific-routes.erb", :cookbook => 'nginx-app', :variables => {


### PR DESCRIPTION
we are using `cache_config` at some points for browser config, others for nginx config - this gets confusing, so I changed it.

fixes DEVOPS-157