### PR TITLE
Adds DATABASE_URL to app's environment

### DIFF
--- a/easybib/libraries/config.rb
+++ b/easybib/libraries/config.rb
@@ -46,12 +46,9 @@ module EasyBib
         # add configuration from the RDS resource management in opsworks
         Chef::Log.info('found configured rds resource, adding to envvars')
         dbconfig = streamline_appenv('db' => node['deploy'][appname]['database'])
+        dbconfig = append_database_url_to_dbconfig(dbconfig)
+
         settings.merge!(dbconfig)
-        if dbconfig['db']['database'] && dbconfig['db']['host'] && dbconfig['db']['port'] && dbconfig['db']['username'] && dbconfig['db']['password']
-          db_type = dbconfig['db']['type'] == 'mysql' ? 'mysql2' : dbconfig['db']['type']
-          db_url = "#{db_type}://#{dbconfig['db']['username']}:#{dbconfig['db']['password']}@#{dbconfig['db']['host']}:#{dbconfig['db']['port']}/#{dbconfig['db']['database']}?reconnect=#{dbconfig['db']['reconnect']}"
-          settings.merge!('database' => { 'url' => db_url } )
-        end
       end
 
       data = {
@@ -379,6 +376,26 @@ module EasyBib
     # extracts the path where an application is deployed
     def get_app_dir(deploy_to)
       "#{deploy_to}/current/"
+    end
+
+    def append_database_url_to_dbconfig(dbconfig)
+      return unless dbconfig
+
+      return dbconfig unless dbconfig['DB_DATABASE']
+      return dbconfig unless dbconfig['DB_HOST']
+      return dbconfig unless dbconfig['DB_PORT']
+      return dbconfig unless dbconfig['DB_USERNAME']
+      return dbconfig unless dbconfig['DB_PASSWORD']
+
+      db_type = dbconfig['DB_TYPE'] == 'mysql' ? 'mysql2' : dbconfig['DB_TYPE']
+
+      db_url = "#{db_type}://#{dbconfig['DB_USERNAME']}:#{dbconfig['DB_PASSWORD']}@" \
+               "#{dbconfig['DB_HOST']}:#{dbconfig['DB_PORT']}/" \
+               "#{dbconfig['DB_DATABASE']}?reconnect=#{dbconfig['DB_RECONNECT']}"
+
+      dbconfig['DATABASE_URL'] = db_url
+
+      dbconfig
     end
   end
 end

--- a/easybib/libraries/config.rb
+++ b/easybib/libraries/config.rb
@@ -47,6 +47,11 @@ module EasyBib
         Chef::Log.info('found configured rds resource, adding to envvars')
         dbconfig = streamline_appenv('db' => node['deploy'][appname]['database'])
         settings.merge!(dbconfig)
+        if dbconfig['db']['database'] && dbconfig['db']['host'] && dbconfig['db']['port'] && dbconfig['db']['username'] && dbconfig['db']['password']
+          db_type = dbconfig['db']['type'] == 'mysql' ? 'mysql2' : dbconfig['db']['type']
+          db_url = "#{db_type}://#{dbconfig['db']['username']}:#{dbconfig['db']['password']}@#{dbconfig['db']['host']}:#{dbconfig['db']['port']}/#{dbconfig['db']['database']}?reconnect=#{dbconfig['db']['reconnect']}"
+          settings.merge!('database' => { 'url' => db_url } )
+        end
       end
 
       data = {

--- a/easybib/tests/test_config.rb
+++ b/easybib/tests/test_config.rb
@@ -94,14 +94,19 @@ BLA_SOMEARRAY[1] = \"server2\"\n",
     )
   end
 
+  # rubocop:disable Metrics/MethodLength
   def test_config_with_rds_to_ini
     # IMPORTANT: Do not use port as string, since we want to check if no
     # Fixnum to string error happens
     fake_node = get_fakenode_config
     fake_node.set['deploy']['some_app']['database'] = {
+      'type' => 'mysql',
       'host' => 'some.db.tld',
-      'user' => 'dbuser',
-      'port' => 1234
+      'username' => 'dbuser',
+      'password' => 'somepass',
+      'database' => 'somedb',
+      'port' => 1234,
+      'reconnect' => true
     }
 
     assert_equal(
@@ -119,12 +124,18 @@ BLA_SOMEKEY = \"somevalue\"
 BLA_SOMEGROUP_SOMEOTHERKEY = \"someothervalue\"
 BLA_SOMEARRAY[0] = \"server1\"
 BLA_SOMEARRAY[1] = \"server2\"
+DB_TYPE = \"mysql\"
 DB_HOST = \"some.db.tld\"
-DB_USER = \"dbuser\"
-DB_PORT = \"1234\"\n",
+DB_USERNAME = \"dbuser\"
+DB_PASSWORD = \"somepass\"
+DB_DATABASE = \"somedb\"
+DB_PORT = \"1234\"
+DB_RECONNECT = \"true\"
+DATABASE_URL = \"mysql2://dbuser:somepass@some.db.tld:1234/somedb?reconnect=true\"\n",
       ::EasyBib::Config.get_configcontent('ini', 'some_app', fake_node)
     )
   end
+  # rubocop:enable Metrics/MethodLength
 
   def test_config_to_shell
     assert_equal("export DEPLOYED_APPLICATION_APPNAME=\"some_app\"


### PR DESCRIPTION
The ``DATABASE_URL`` is a environment variable used e.g. in the Ruby ecosystem. It is a composite of all DB details in form of a URL like this:

```
mysql2://user:password@host:port/database?reconnect=true
```

This patch creates that variable in case that all necessary parts are set in the DB config.