### PR TITLE
Adds DATABASE_URL to app's environment

### DIFF
--- a/easybib/libraries/config.rb
+++ b/easybib/libraries/config.rb
@@ -47,6 +47,11 @@ module EasyBib
         Chef::Log.info('found configured rds resource, adding to envvars')
         dbconfig = streamline_appenv('db' => node['deploy'][appname]['database'])
         settings.merge!(dbconfig)
+        if dbconfig['db']['database'] && dbconfig['db']['host'] && dbconfig['db']['port'] && dbconfig['db']['username'] && dbconfig['db']['password']
+          db_type = dbconfig['db']['type'] == 'mysql' ? 'mysql2' : dbconfig['db']['type']
+          db_url = "#{db_type}://#{dbconfig['db']['username']}:#{dbconfig['db']['password']}@#{dbconfig['db']['host']}:#{dbconfig['db']['port']}/#{dbconfig['db']['database']}?reconnect=#{dbconfig['db']['reconnect']}"
+          settings.merge!('database' => { 'url' => db_url } )
+        end
       end
 
       data = {


### PR DESCRIPTION
The ``DATABASE_URL`` is a environment variable used e.g. in the Ruby ecosystem. It is a composite of all DB details in form of a URL like this:

```
mysql2://user:password@host:port/database?reconnect=true
```

This patch creates that variable in case that all necessary parts are set in the DB config.