### PR TITLE
Change: update options

### DIFF
--- a/haproxy/templates/default/haproxy.cfg.backend.erb
+++ b/haproxy/templates/default/haproxy.cfg.backend.erb
@@ -21,9 +21,6 @@ end
 
 backend <%= @layername %>_php_app_servers
   balance roundrobin
-  option redispatch
-  option httpclose
-  option forwardfor except 127.0.0.1
   option httpchk <%= health_check_string %>
   <%
 instances = @node.fetch('opsworks', {}).fetch('layers', {}).fetch(@layername, {})['instances']

--- a/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
@@ -22,7 +22,6 @@ end
 backend <%= @layername %>_forward
   balance roundrobin
   option redispatch
-  option httpclose
   option forwardfor except 127.0.0.1
   option httpchk <%= health_check_string %>
   <% @servers.each do |name,host| -%>

--- a/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
@@ -21,8 +21,6 @@ end
 
 backend <%= @layername %>_forward
   balance roundrobin
-  option redispatch
-  option forwardfor except 127.0.0.1
   option httpchk <%= health_check_string %>
   <% @servers.each do |name,host| -%>
   server <%= name %> <%= host %>:80 weight 10 maxconn <%= haproxy_maxconn %> rise <%= haproxy_rise %> fall <%= haproxy_fall %> check inter <%= haproxy_check_interval %>

--- a/haproxy/templates/default/haproxy.cfg.globals.erb
+++ b/haproxy/templates/default/haproxy.cfg.globals.erb
@@ -25,7 +25,8 @@ defaults
   timeout client  50000
   timeout server  50000
   option          redispatch
-  option          httpclose     # disable keepalive (HAProxy does not yet support the HTTP keep-alive mode)
+  option          forwardfor        # X-Forwarded-For header
+  option          http-server-close # close connection, but maintain keep-alive
   option          abortonclose  # enable early dropping of aborted requests from pending queue
   option          httpchk       # enable HTTP protocol to check on servers health
 <% if @node['haproxy']['enable_stats'] -%>

--- a/haproxy/templates/default/haproxy.cfg.globals.erb
+++ b/haproxy/templates/default/haproxy.cfg.globals.erb
@@ -25,10 +25,10 @@ defaults
   timeout client  50000
   timeout server  50000
   option          redispatch
-  option          forwardfor        # X-Forwarded-For header
-  option          http-server-close # close connection, but maintain keep-alive
-  option          abortonclose  # enable early dropping of aborted requests from pending queue
-  option          httpchk       # enable HTTP protocol to check on servers health
+  option          forwardfor except 127.0.0.1 # X-Forwarded-For header
+  option          http-server-close           # close connection, but maintain keep-alive
+  option          abortonclose                # enable early dropping of aborted requests from pending queue
+  option          httpchk                     # enable HTTP protocol to check on servers health
 <% if @node['haproxy']['enable_stats'] -%>
   stats auth <%= @node['haproxy']['stats_user'] %>:<%= @node['haproxy']['stats_password'] %>
   stats uri <%= @node['haproxy']['stats_url'] %>

--- a/haproxy/templates/default/haproxy.cfg.websocketbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.websocketbackend.erb
@@ -29,8 +29,6 @@ end
 
 backend <%= @layername %>_websocket_app_servers
   balance roundrobin
-  option redispatch
-  option forwardfor except 127.0.0.1
   option httpchk <%= health_check_string %>
   http-check expect status 101
   timeout tunnel 3600s


### PR DESCRIPTION
 * prep for more let's encrypt work
 * forwardfor: add x-forwarded-for header
 * http-server-close:
   * close connections between user and haproxy
   * maintain keep-alive
 * remove redunant option in backend (matched global)

Related: DEVOPS-163