### PR TITLE
Update: allow empty credentials

### DIFF
--- a/ies-route53/libraries/helper.rb
+++ b/ies-route53/libraries/helper.rb
@@ -1,9 +1,20 @@
 module IesRoute53
   module Helper
-    def dns_enabled?(node = self.node)
-      zone_config = node.fetch('ies-route53', {}).fetch('zone', {})
+    def get_aws_config(node = self.node)
+      config = get_zone_config(node)
 
-      %w(id custom_access_key custom_secret_key).each do |attrib|
+      {
+        :access_key => config.fetch('custom_access_key', nil),
+        :secret => config.fetch('custom_secret_key', nil),
+        :zone_id => config.fetch('id', nil)
+      }
+    end
+
+    def dns_enabled?(node = self.node)
+      zone_config = get_zone_config(node)
+
+      # custom_access_key & custom_secret_key are optional
+      %w(id).each do |attrib|
         unless zone_config.key?(attrib)
           return false
         end
@@ -14,6 +25,12 @@ module IesRoute53
       end
 
       true
+    end
+
+    private
+
+    def get_zone_config(node)
+      node.fetch('ies-route53', {}).fetch('zone', {})
     end
   end
 end

--- a/ies-route53/providers/record.rb
+++ b/ies-route53/providers/record.rb
@@ -7,12 +7,21 @@ action :create do
 
   Chef::Log.info('Preparing IES-Route53 Record Update...')
 
-  route_53_credential_provider = AWS::Core::CredentialProviders::StaticProvider.new(
-    :access_key_id => new_resource.aws_access_key_id,
-    :secret_access_key => new_resource.aws_secret_access_key
-  )
+  access_key = new_resource.aws_access_key_id
+  secret_key = new_resource.aws_secret_access_key
 
-  route53_client = AWS::Route53.new(:credential_provider => route_53_credential_provider)
+  if access_key.nil? || secret_key.nil?
+    route53_client = AWS::Route53.new
+  else
+    route_53_credential_provider = AWS::Core::CredentialProviders::StaticProvider.new(
+      :access_key_id => access_key,
+      :secret_access_key => secret_key
+    )
+
+    route53_client = AWS::Route53.new(
+      :credential_provider => route_53_credential_provider
+    )
+  end
 
   zone_id = new_resource.zone_id
   overwrite = new_resource.overwrite

--- a/ies-route53/recipes/add.rb
+++ b/ies-route53/recipes/add.rb
@@ -1,13 +1,15 @@
 instance = get_instance
 
+aws_config = get_aws_config
+
 ies_route53_record 'create a record' do
   name                  get_record_name
   value                 instance['ip']
   type                  'A'
   ttl                   node['ies-route53']['zone']['ttl']
-  zone_id               node['ies-route53']['zone']['id']
-  aws_access_key_id     node['ies-route53']['zone']['custom_access_key']
-  aws_secret_access_key node['ies-route53']['zone']['custom_secret_key']
+  zone_id               aws_config[:zone_id]
+  aws_access_key_id     aws_config[:access_key]
+  aws_secret_access_key aws_config[:secret]
   overwrite true
   action :create
   only_if do

--- a/ies-route53/resources/record.rb
+++ b/ies-route53/resources/record.rb
@@ -7,6 +7,6 @@ attribute :name,                  :kind_of => String, :required => true, :name_a
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :type,                  :kind_of => String, :required => true
 attribute :value,                 :kind_of => String, :required => true
-attribute :aws_access_key_id,     :kind_of => String
-attribute :aws_secret_access_key, :kind_of => String
+attribute :aws_access_key_id,     :kind_of => [String, NilClass]
+attribute :aws_secret_access_key, :kind_of => [String, NilClass]
 attribute :overwrite,             :kind_of => [TrueClass, FalseClass], :default => true

--- a/ies-route53/spec/add_spec.rb
+++ b/ies-route53/spec/add_spec.rb
@@ -54,5 +54,25 @@ describe 'ies-route53::add' do
           )
       end
     end
+
+    describe 'credential auto discovery' do
+      before do
+        node.set['ies-route53']['zone'] = {
+          'ttl' => 2,
+          'id' => 'bar'
+        }
+      end
+
+      it "doesn't need access key id and secret" do
+        expect(chef_run).to create_ies_route53_record('spec.chefspec.local')
+          .with(
+            :name => 'spec.chefspec.local',
+            :value => '127.0.0.8',
+            :type => 'A',
+            :ttl => 2,
+            :zone_id => 'bar'
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
This can be discovered using the instance role when required
and saves us from having yet another IAM user that is setup
in order to do something in Chef.

## How to test?

 * Setup an instance profile on the new sparkle notebook playground.
 * Assign profile rights to access:
   * Route53 (see specific zone_id in custom json)
   * S3 (just for completeness)
 * start stack, check if A record is created

