### PR TITLE
Easybib: run workers as www not edu in vagrant

### DIFF
--- a/nginx-app/recipes/vagrant-silex.rb
+++ b/nginx-app/recipes/vagrant-silex.rb
@@ -42,6 +42,7 @@ node['vagrant']['applications'].each do |app_name, app_config|
     stackname stackname
   end
 
+  next if app_name == 'edu'
   easybib_supervisor "#{app_name}_supervisor" do
     supervisor_file "#{app_dir}/deploy/supervisor.json"
     app_dir app_dir

--- a/stack-easybib/recipes/deploy-webapps-vagrant.rb
+++ b/stack-easybib/recipes/deploy-webapps-vagrant.rb
@@ -11,4 +11,13 @@
     notifies :reload, 'service[nginx]', :delayed
     notifies :restart, 'service[php-fpm]', :delayed
   end
+
+  next unless app == 'www'
+  app_dir = node['vagrant']['applications'][app]['app_root_location']
+  easybib_supervisor "#{app}_supervisor" do
+    supervisor_file "#{app_dir}/deploy/supervisor.json"
+    app_dir app_dir
+    app app
+    user node['php-fpm']['user']
+  end
 end


### PR DESCRIPTION
https://github.com/easybib/sbm-issues/issues/524

Make sure that SQS workers inside vagrant are run as www (same as playground/production) and not edu