### PR TITLE
Reload FPM after deploying PDF-Autocite

### DIFF
--- a/stack-citationapi/recipes/deploy-citationapi.rb
+++ b/stack-citationapi/recipes/deploy-citationapi.rb
@@ -64,6 +64,7 @@ node['deploy'].each do |application, deploy|
     default_router default_router
     domain_name domain_name
     notifies :reload, 'service[nginx]', :delayed
+    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 
   easybib_envconfig application


### PR DESCRIPTION
Jira: https://imagineeasy.atlassian.net/browse/DEVOPS-168

@appmode just noticed a bug where FPM is not reloaded after deployment of PDF-Autocite. Here is the fix.