### PR TITLE
Cleanup node[easybib-deploy]

### DIFF
--- a/easybib-deploy/attributes/default.rb
+++ b/easybib-deploy/attributes/default.rb
@@ -1,8 +1,4 @@
-default['easybib-deploy'] = {
-  'php-fpm' => {
-    'restart-action' => :reload
-  }
-}
+default['easybib_deploy']['php-fpm']['restart-action'] = :reload
 
 default['ssl-deploy'] = {}
 default['ssl-deploy']['directory'] = '/etc/nginx/ssl'

--- a/easybib-deploy/recipes/easybib.rb
+++ b/easybib-deploy/recipes/easybib.rb
@@ -32,7 +32,7 @@ node['deploy'].each do |application, deploy|
   end
 
   service 'php-fpm' do
-    action node['easybib-deploy']['php-fpm']['restart-action']
+    action node['easybib_deploy']['php-fpm']['restart-action']
   end
 
 end

--- a/easybib-deploy/recipes/qa.rb
+++ b/easybib-deploy/recipes/qa.rb
@@ -65,7 +65,7 @@ node['deploy'].each do |application, deploy|
   end
 
   service 'php-fpm' do
-    action node['easybib-deploy']['php-fpm']['restart-action']
+    action node['easybib_deploy']['php-fpm']['restart-action']
   end
 
 end

--- a/easybib-deploy/recipes/silex.rb
+++ b/easybib-deploy/recipes/silex.rb
@@ -33,6 +33,6 @@ node['deploy'].each do |application, deploy|
     htpasswd "#{deploy['deploy_to']}/current/htpasswd"
     listen_opts listen_opts
     notifies :reload, 'service[nginx]', :delayed
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 end

--- a/easybib/attributes/default.rb
+++ b/easybib/attributes/default.rb
@@ -1,4 +1,3 @@
-default['easybib_deploy']                  = {}
 default['easybib_deploy']['gearman_file']  = 'pecl_manager_env'
 default['easybib_deploy']['env_source']    = nil
 default['easybib_deploy']['provide_pear']  = false

--- a/easybib/providers/deploy_manager.rb
+++ b/easybib/providers/deploy_manager.rb
@@ -75,7 +75,7 @@ def run_deploys(deployments, app_name, app_data)
       htpasswd "#{deploy['deploy_to']}/current/htpasswd"
       listen_opts listen_opts
       notifies :reload, 'service[nginx]', :delayed
-      notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+      notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
     end
   end
 

--- a/stack-citationapi/recipes/deploy-citationapi.rb
+++ b/stack-citationapi/recipes/deploy-citationapi.rb
@@ -37,7 +37,7 @@ node['deploy'].each do |application, deploy|
       cookbook 'stack-citationapi'
       config_template 'default-web-nginx.conf.erb'
       notifies :reload, 'service[nginx]', :delayed
-      notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+      notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
     end
 
     next
@@ -64,7 +64,7 @@ node['deploy'].each do |application, deploy|
     default_router default_router
     domain_name domain_name
     notifies :reload, 'service[nginx]', :delayed
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 
   easybib_envconfig application

--- a/stack-easybib/recipes/deploy-easybib.rb
+++ b/stack-easybib/recipes/deploy-easybib.rb
@@ -35,6 +35,6 @@ node['deploy'].each do |application, deploy|
     config_template 'easybib.com.conf.erb'
     nginx_extras nginx_extras
     notifies :reload, 'service[nginx]', :delayed
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 end

--- a/stack-easybib/recipes/deploy-silexapps.rb
+++ b/stack-easybib/recipes/deploy-silexapps.rb
@@ -20,6 +20,6 @@ node['deploy'].each do |application, deploy|
     cookbook 'stack-easybib'
     config_template 'silex.conf.erb'
     notifies :reload, 'service[nginx]', :delayed
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 end

--- a/stack-research/recipes/deploy-research.rb
+++ b/stack-research/recipes/deploy-research.rb
@@ -14,7 +14,7 @@ node['deploy'].each do |application, deploy|
   easybib_deploy application do
     deploy_data deploy
     app application
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]'
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]'
   end
 
   # clean up old config before migration
@@ -27,7 +27,7 @@ node['deploy'].each do |application, deploy|
     cookbook 'stack-research'
     config_template 'research-app.conf.erb'
     notifies :reload, 'service[nginx]', :delayed
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 
 end

--- a/stack-test/recipes/deploy.rb
+++ b/stack-test/recipes/deploy.rb
@@ -26,7 +26,7 @@ node['deploy'].each do |application, deploy|
     doc_root deploy['document_root']
     listen_opts nil
     notifies :reload, 'service[nginx]', :delayed
-    notifies node['easybib-deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
+    notifies node['easybib_deploy']['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 
 end


### PR DESCRIPTION
This PR replaces all occurrences of `node[easybib-deploy]` with `node[easybib_deploy]` (note: the underscore). See easybib/ops#15.

Please merge to master **AFTER** the next stable merge to win us enough time for stabilization.