### PR TITLE
Publish Berkshelf artefacts to S3 #169

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_deploy:
   - tar cfz easybib-cookbooks.tar.gz * --exclude=easybib-cookbooks.tar.gz --exclude=vendor/
   - mkdir build
   - mv easybib-cookbooks.tar.gz build/
+  - mv */cookbooks-*.tar.gz build/
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_deploy:
   - tar cfz easybib-cookbooks.tar.gz * --exclude=easybib-cookbooks.tar.gz --exclude=vendor/
   - mkdir build
   - mv easybib-cookbooks.tar.gz build/
-  - mv */cookbooks-*.tar.gz build/
+  - bash MoveBerkshelfArtifacts.sh
 
 deploy:
   - provider: s3

--- a/MoveBerkshelfArtifacts.sh
+++ b/MoveBerkshelfArtifacts.sh
@@ -5,7 +5,7 @@ TARGET_PATTERN="*/cookbooks-*.tar.gz"
 for FILE in `ls */cookbooks-*.tar.gz`; do
 	BASE=`basename $FILE`
 	DIR=`dirname $FILE`
-	mv $FILE build/$DIR.tar.gz
+	mv $FILE build/artifact-$DIR.tar.gz
 done
 
 exit 0

--- a/MoveBerkshelfArtifacts.sh
+++ b/MoveBerkshelfArtifacts.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TARGET_PATTERN="*/cookbooks-*.tar.gz"
+
+for FILE in `ls */cookbooks-*.tar.gz`; do
+	BASE=`basename $FILE`
+	DIR=`dirname $FILE`
+	mv $FILE build/$DIR.tar.gz
+done
+
+exit 0
+


### PR DESCRIPTION
Refers to https://github.com/easybib/ops/issues/169

* add call to a shell script to MoveBerkshelfArtifacts.sh 
* create MoveBerkshelfArtifacts.sh which just moves and renames them to `build/artifact-_container_.tar.gz`
