### PR TITLE
Improve MoveBerkshelfArtifacts.sh

### DIFF
--- a/MoveBerkshelfArtifacts.sh
+++ b/MoveBerkshelfArtifacts.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
+set -e
+shopt -s nullglob
+
 TARGET_PATTERN="*/cookbooks-*.tar.gz"
 
-for FILE in `ls */cookbooks-*.tar.gz`; do
-	BASE=`basename $FILE`
-	DIR=`dirname $FILE`
-	mv $FILE build/artifact-$DIR.tar.gz
+if [[ ! -r ./MoveBerkshelfArtifacts.sh ]]; then
+    echo "Please make sure you are in the cookbook root directory!"
+    exit 1
+fi
+
+mkdir -p build
+
+for FILE in ${TARGET_PATTERN}; do
+    BASE=$(basename $FILE)
+    DIR=$(dirname $FILE)
+    printf "%-50s => %s\n" "$FILE"  "build/artifact-${DIR}.tar.gz'"
+    mv "$FILE" "build/artifact-${DIR}.tar.gz"
 done
-
-exit 0
-


### PR DESCRIPTION
- don't use sh syntax in Bash
- create missing directories
- never use the output of ls in for loops (http://mywiki.wooledge.org/ParsingLs)
- always quote path variables