### PR TITLE
CMBM: Cleanup old puma procs on app redeployment

### DIFF
--- a/easybib/libraries/config.rb
+++ b/easybib/libraries/config.rb
@@ -30,7 +30,7 @@ module EasyBib
     end
 
     # returns env settings and information about the stack, application env, and rds
-    def get_configcontent(format, appname, node = self.node, stackname = 'getcourse')
+    def get_configcontent(format, appname, node = self.node, stackname = 'getcourse')  # rubocop:disable Metrics/AbcSize
       settings = {}
       unless node.fetch(stackname, {})['env'].nil?
         Chef::Log.info("env settings for stack #{stackname} found")
@@ -49,6 +49,14 @@ module EasyBib
         dbconfig = append_database_url_to_dbconfig(dbconfig)
 
         settings.merge!(dbconfig)
+      end
+
+      if node.fetch('deploy', {}).fetch(appname, {}).fetch('puma', {}).fetch('rundir', nil).nil?
+        # add configuration from the stack's default attributes
+        Chef::Log.info('did not find puma rundir in stack settings, falling back to default attributes!')
+        puma_config = streamline_appenv('puma' => node.fetch('stack-cmbm', {}).fetch('puma', {}))
+
+        settings.merge!(puma_config)
       end
 
       data = {

--- a/stack-cmbm/attributes/default.rb
+++ b/stack-cmbm/attributes/default.rb
@@ -1,0 +1,1 @@
+default['stack-cmbm']['puma']['rundir'] = '/var/run/puma'

--- a/stack-cmbm/recipes/deploy-nginxapp.rb
+++ b/stack-cmbm/recipes/deploy-nginxapp.rb
@@ -33,6 +33,7 @@ applications.each do |app_name, app_config|
   app_dir            = app_data['app_dir']
   app_ruby           = node.fetch(app_name, {}).fetch('env', {}).fetch('ruby', {}).fetch('version', '')
   gem_home           = node.fetch(app_name, {}).fetch('env', {}).fetch('gem', {}).fetch('home', '')
+  rundir             = node.fetch(app_name, {}).fetch('puma', {}).fetch('rundir', app_dir)
 
   next if app_name == 'ssl'
 
@@ -59,6 +60,12 @@ applications.each do |app_name, app_config|
     domain_name domain_name
     app_dir app_dir
     notifies :reload, 'service[nginx]', :delayed
+  end
+
+  directory rundir do
+    owner user
+    group user
+    mode '0755'
   end
 
   supervisor_service "#{app_name}_supervisor" do


### PR DESCRIPTION
Issue: easybib/ops#186

This PR prepares our cookbooks for a vital change in CMBM that is currently causing old puma instances to not be torn down correctly during app redeployments.