### PR TITLE
Install xvfb into CMBM vagrant box

### DIFF
--- a/stack-cmbm/recipes/role-vagrant.rb
+++ b/stack-cmbm/recipes/role-vagrant.rb
@@ -7,6 +7,9 @@ include_recipe 'ies-mysql::dev'
 include_recipe 'ies-zsh'
 include_recipe 'redis'
 
+# Install xvfb, see: https://github.com/easybib/ops/issues/197
+package 'xvfb'
+
 # Pull in the production role-* recipe.
 include_recipe 'stack-cmbm::role-nginxapp'
 include_recipe 'stack-cmbm::deploy-vagrant'

--- a/stack-cmbm/spec/role-vagrant_spec.rb
+++ b/stack-cmbm/spec/role-vagrant_spec.rb
@@ -1,0 +1,31 @@
+require_relative 'spec_helper.rb'
+
+describe 'stack-cmbm::role-vagrant' do
+
+  let(:runner)    { ChefSpec::Runner.new }
+  let(:chef_run)  { runner.converge(described_recipe) }
+  let(:node)      { runner.node }
+
+  before do
+    node.set[:vagrant][:applications] = {
+      :cmbm => {
+        :app_root_location => '/vagrant_cmbm',
+        :doc_root_location => '/vagrant_cmbm/public'
+      }
+    }
+  end
+
+  it 'pulls in all required recipes' do
+    expect(chef_run).to include_recipe('ies::role-generic')
+    expect(chef_run).to include_recipe('ies-mysql')
+    expect(chef_run).to include_recipe('ies-mysql::dev')
+    expect(chef_run).to include_recipe('ies-zsh')
+    expect(chef_run).to include_recipe('redis')
+    expect(chef_run).to include_recipe('stack-cmbm::role-nginxapp')
+    expect(chef_run).to include_recipe('stack-cmbm::deploy-vagrant')
+  end
+
+  it 'installs all packages required extra on the vagrant box' do
+    expect(chef_run).to install_package('xvfb')
+  end
+end


### PR DESCRIPTION
# Changes
This PR installs the package `xvfb` to the CMBM Vagrant box. The package is needed for testing.

Related: easybib/ops#197

