### PR TITLE
Make nginx aware of the new rundir, remove second param storage

### DIFF
--- a/easybib/libraries/config.rb
+++ b/easybib/libraries/config.rb
@@ -30,7 +30,7 @@ module EasyBib
     end
 
     # returns env settings and information about the stack, application env, and rds
-    def get_configcontent(format, appname, node = self.node, stackname = 'getcourse')  # rubocop:disable Metrics/AbcSize
+    def get_configcontent(format, appname, node = self.node, stackname = 'getcourse')
       settings = {}
       unless node.fetch(stackname, {})['env'].nil?
         Chef::Log.info("env settings for stack #{stackname} found")
@@ -51,13 +51,8 @@ module EasyBib
         settings.merge!(dbconfig)
       end
 
-      if node.fetch('deploy', {}).fetch(appname, {}).fetch('puma', {}).fetch('rundir', nil).nil?
-        # add configuration from the stack's default attributes
-        Chef::Log.info('did not find puma rundir in stack settings, falling back to default attributes!')
-        puma_config = streamline_appenv('puma' => node.fetch('stack-cmbm', {}).fetch('puma', {}))
-
-        settings.merge!(puma_config)
-      end
+      puma_config = streamline_appenv('puma' => node.fetch('stack-cmbm', {}).fetch('puma', {}))
+      settings.merge!(puma_config)
 
       data = {
         'deployed_application' => get_appdata(node, appname),

--- a/stack-cmbm/recipes/deploy-nginxapp.rb
+++ b/stack-cmbm/recipes/deploy-nginxapp.rb
@@ -33,7 +33,7 @@ applications.each do |app_name, app_config|
   app_dir            = app_data['app_dir']
   app_ruby           = node.fetch(app_name, {}).fetch('env', {}).fetch('ruby', {}).fetch('version', '')
   gem_home           = node.fetch(app_name, {}).fetch('env', {}).fetch('gem', {}).fetch('home', '')
-  rundir             = node.fetch(app_name, {}).fetch('puma', {}).fetch('rundir', app_dir)
+  rundir             = node['stack-cmbm']['puma']['rundir']
 
   next if app_name == 'ssl'
 

--- a/stack-cmbm/templates/default/default-web-nginx.conf.erb
+++ b/stack-cmbm/templates/default/default-web-nginx.conf.erb
@@ -52,7 +52,7 @@ server {
         proxy_set_header  X-Real-IP         $remote_addr;
         proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header  X-Forwarded-Proto $scheme;
-        proxy_pass        http://unix:<%= @app_dir %>/puma.sock:;
+        proxy_pass        http://unix:<%= node['stack-cmbm']['puma']['rundir']%>/<%= @app_name %>.sock:;
     }
 
 <% unless node['nginx-app']['browser_caching'].nil? -%>


### PR DESCRIPTION
The new rundir settings were broken:

* nginx was not at all aware of the new ones
* the deploy recipe only respected the app specific one

Since there is no use case currently for the app specific path, I opted to migrate everything to the global config, and clean things up.

Already tested on cm in opsworks, works.