### PR TITLE
Reload supervisor to fix stale Puma instances

### DIFF
--- a/stack-cmbm/recipes/deploy-nginxapp.rb
+++ b/stack-cmbm/recipes/deploy-nginxapp.rb
@@ -71,13 +71,13 @@ applications.each do |app_name, app_config|
   supervisor_service "#{app_name}_supervisor" do
     action [:enable, :restart]
     autostart true
-    command "bash -l -c 'cd #{app_dir}; source .deploy_configuration.sh; #{gem_home}/bin/puma -C config/puma.rb config.ru'"
+    command "bash -l -c 'cd #{app_dir}; source .deploy_configuration.sh; exec #{gem_home}/bin/puma -C config/puma.rb config.ru'"
     numprocs 1
     numprocs_start 0
     priority 999
     autostart true
     autorestart true
-    startsecs 0
+    startsecs 1
     startretries 3
     stopsignal 'TERM'
     stopwaitsecs 10


### PR DESCRIPTION
# Changes

Fork Puma directly under supervisor to prevent orphaned child processes when supervisor reloads and/or restarts.

P.S.: Additionally grant Puma at least one second to start up as zero doesn't seem to make sense and all our other stacks have one second configured, as well.

# CR

 - Test by redeploying the CM or BM application in playground and note how they stay available.
 - please update the stable PR post-merge

Related: easybib/ops#186

