### PR TITLE
Easybib depends on supervisor; pull it in

### DIFF
--- a/stack-easybib/recipes/role-phpapp.rb
+++ b/stack-easybib/recipes/role-phpapp.rb
@@ -1,4 +1,5 @@
 include_recipe 'ies::role-phpapp'
+include_recipe 'supervisor'
 
 include_recipe 'php::module-soap'
 include_recipe 'php::module-tidy'


### PR DESCRIPTION
# Changes

`stack-easybib` requires supervisor. It is even stated in `metadata.rb` however not included anywhere beneath `stack-easybib::role-phpapp`. This PR includes supervisor so it is actually available when other cookbooks try to use it.

# CR

 - Deploy an nginxapp instance in stack-easybib PG and notice how it doesn't fail due to missing `supervisorctl`.
 - please update the stable PR post-merge

Related: easybib/ops#202

