### PR TITLE
Fix puma+supervisor setup in Vagrant

### DIFF
--- a/stack-cmbm/recipes/deploy-vagrant.rb
+++ b/stack-cmbm/recipes/deploy-vagrant.rb
@@ -46,7 +46,7 @@ node['vagrant']['applications'].each do |app_name, app_config|
   supervisor_service "#{app_name}_supervisor" do
     action [:enable, :restart]
     autostart true
-    command "bash -l -c 'cd #{app_dir}; PUMA_APP=#{app_name} ./vagrant/puma-vagrant.sh'"
+    command "bash -l -c 'cd #{app_dir}; PUMA_APP=#{app_name} exec ./vagrant/puma-vagrant.sh'"
     numprocs 1
     numprocs_start 0
     priority 999


### PR DESCRIPTION
# Changes

We have been seeing problems with supervisor not managing puma correctly. Beforehand, we spawned puma using a small Bash helper (which ensured the correct environment). This leads to the fact, that supervisor in fact manages the Bash child and the kernel moving the actual puma processes under Init when the parent Bash died (standard Linux behaviour of unparented processes).

I prepared a fix last week, but didn't consider that this also happens in Vagrant, as well.

This PR makes sure that Puma is always the direct child of the supervisor process in CMBM vagrant box.

This PR only leads to a working result if https://github.com/easybib/citationmachine-bibme/pull/1207 is also merged.

# CR

 - Spin up the Vagrant box of CMBM and issue `supervisorctl restart all`. Not how the puma processes restart successfully.
 - please update the stable PR post-merge

Related: easybib/ops#186

- ensure that supervisor always manages the puma process directly
  without any additional shell-levels between puma and supervisor.