### PR TITLE
Scale-out of Sinopia Cookbook

### DIFF
--- a/ies-sinopia/README.md
+++ b/ies-sinopia/README.md
@@ -1,0 +1,2 @@
+# Cookbook: IES-Sinopia
+A wrapper around the `sinopia` cookbook containing some IES specific patches.

--- a/ies-sinopia/metadata.rb
+++ b/ies-sinopia/metadata.rb
@@ -1,0 +1,8 @@
+name             'ies-sinopia'
+maintainer       'Brian Wiborg'
+maintainer_email 'bwiborg@chegg.com'
+license          'Apache 2.0'
+description      'Wrapper around sinopia cookbook containing some IES specific patches.'
+version          '0.1.0'
+
+depends 'sinopia'

--- a/ies-sinopia/recipes/default.rb
+++ b/ies-sinopia/recipes/default.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+#
+# Cookbook Name:: sinopia
+# Recipe:: default
+#
+# Copyright (C) 2014 Barthelemy Vessemont
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'ies-sinopia::users'
+include_recipe 'sinopia::nodejs'
+include_recipe 'sinopia::sinopia'

--- a/ies-sinopia/recipes/users.rb
+++ b/ies-sinopia/recipes/users.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+
+user node['sinopia']['user'] do
+  shell '/bin/nologin'
+  system true
+  manage_home true
+end

--- a/ies-sinopia/spec/default_spec.rb
+++ b/ies-sinopia/spec/default_spec.rb
@@ -1,0 +1,12 @@
+require_relative 'spec_helper'
+
+describe 'ies-sinopia::default' do
+  let(:runner)   { ChefSpec::Runner.new }
+  let(:chef_run) { runner.converge(described_recipe) }
+
+  it 'includes all required recipes' do
+    expect(chef_run).to include_recipe('ies-sinopia::default')
+    expect(chef_run).to include_recipe('sinopia::nodejs')
+    expect(chef_run).to include_recipe('sinopia::sinopia')
+  end
+end

--- a/ies-sinopia/spec/spec_helper.rb
+++ b/ies-sinopia/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'chefspec'
+
+RSpec.configure do |config|
+  config.platform = 'ubuntu'
+  config.version = '14.04'
+end

--- a/ies-sinopia/spec/users_spec.rb
+++ b/ies-sinopia/spec/users_spec.rb
@@ -1,0 +1,14 @@
+require_relative 'spec_helper'
+
+describe 'ies-sinopia::users' do
+  let(:runner)   { ChefSpec::Runner.new }
+  let(:chef_run) { runner.converge(described_recipe) }
+
+  it 'creates the sinopia user' do
+    expect(chef_run).to create_user('sinopia').with(
+      :shell => '/bin/nologin',
+      :system => true,
+      :manage_home => true
+    )
+  end
+end


### PR DESCRIPTION
# Change

This PR scales-out our changes to the upstream `Sinopia` cookbook into `ies-sinopia`.

# CR

- please update the stable PR post-merge

Related: easybib/ops#213
