### PR TITLE
T/scale out chef sns handler

### DIFF
--- a/ies-chef-handler-sns/README.md
+++ b/ies-chef-handler-sns/README.md
@@ -1,0 +1,2 @@
+# Cookbook: IES-Chef-SNS-Handler
+Wrapper around `chef_sns_handler` cookbook containing some IES specific patches.

--- a/ies-chef-handler-sns/files/default/body_template
+++ b/ies-chef-handler-sns/files/default/body_template
@@ -1,0 +1,43 @@
+Node Name: <%= node.name %>
+<% if node.attribute?('fqdn') -%>
+Hostname: <%= node.fqdn %>
+<% end -%>
+
+<% if node.attribute?('opsworks') -%>
+Stack Name: <%= node.opsworks.stack.name %>
+
+<% end -%>
+Chef Version: <%= Chef::VERSION %>
+Ohai Version: <%= Ohai::VERSION %>
+
+Chef Run List: <%= node.run_list.to_s %>
+Chef Environment: <%= node.chef_environment %>
+
+<% if node.attribute?('ec2') -%>
+<%   if node.ec2.attribute?('instance_id') -%>
+Instance Id: <%= node.ec2.instance_id %>
+<%   end -%>
+<%   if node.ec2.attribute?('public_hostname') -%>
+Instance Public Hostname: <%= node.ec2.public_hostname %>
+<%   end -%>
+<%   if node.ec2.attribute?('hostname') -%>
+Instance Hostname: <%= node.ec2.hostname %>
+<%   end -%>
+<%   if node.ec2.attribute?('public_ipv4') -%>
+Instance Public IPv4: <%= node.ec2.public_ipv4 %>
+<%   end -%>
+<%   if node.ec2.attribute?('local_ipv4') -%>
+Instance Local IPv4: <%= node.ec2.local_ipv4 %>
+<%   end -%>
+<% end -%>
+
+Chef Client Elapsed Time: <%= elapsed_time.to_s %>
+Chef Client Start Time: <%= start_time.to_s %>
+Chef Client Start Time: <%= end_time.to_s %>
+
+<% if exception -%>
+Exception: <%= run_status.formatted_exception %>
+Stacktrace:
+<%= Array(backtrace).join("\n") %>
+
+<% end -%>

--- a/ies-chef-handler-sns/metadata.rb
+++ b/ies-chef-handler-sns/metadata.rb
@@ -1,0 +1,12 @@
+name              'ies-chef-handler-sns'
+maintainer        'Brian Wiborg'
+maintainer_email  'bwiborg@chegg.com'
+license           'Apache 2.0'
+description       'Wrapper around chef_handler_sns'
+version           '0.0.1'
+
+%w(ubuntu).each do |os|
+  supports os
+end
+
+depends 'chef_handler_sns'

--- a/ies-chef-handler-sns/recipes/default.rb
+++ b/ies-chef-handler-sns/recipes/default.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: chef_handler_sns
+# Recipe:: default
+#
+# Copyright 2014, Onddo Labs, Sl.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+template_location = Chef::Config[:file_cache_path] + 'chef_handler_sns_template'
+
+cookbook_file template_location do
+  source 'body_template'
+  mode   '0644'
+  owner  'root'
+end
+
+chef_handler_sns node['chef_handler_sns']['topic_arn'] do
+  body_template template_location
+end

--- a/ies-chef-handler-sns/spec/default_spec.rb
+++ b/ies-chef-handler-sns/spec/default_spec.rb
@@ -1,0 +1,16 @@
+require_relative 'spec_helper'
+
+describe 'ies-chef-handler-sns::default' do
+  let(:topic_arn) { 'arn:aws:sns:us-east-1:12341234:MyTopicName' }
+  let(:chef_run) do
+    ChefSpec::Runner.new(:step_into => ['chef_sns_handler']) do |node|
+      node.set['chef_handler_sns']['topic_arn'] = topic_arn
+    end.converge(described_recipe)
+  end
+
+  it 'should create chef_handler_sns resource' do
+    expect(chef_run).to enable_chef_handler_sns(topic_arn).with(
+      :topic_arn => topic_arn
+    )
+  end
+end

--- a/ies-chef-handler-sns/spec/spec_helper.rb
+++ b/ies-chef-handler-sns/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'chefspec'
+
+RSpec.configure do |c|
+  c.platform = 'ubuntu'
+  c.version = '14.04'
+  c.log_level = :error
+end


### PR DESCRIPTION
# Changes

Scale out of our changes to the `chef_handler_sns` to `ies-chef-handler-sns`.

# CR

 - `make test` will include the RSpec tests
 - please update the stable PR post-merge

Related: easybib/ops#213
