### PR TITLE
T/ondreij gearman

### DIFF
--- a/gearmand/recipes/default.rb
+++ b/gearmand/recipes/default.rb
@@ -1,5 +1,6 @@
 include_recipe 'ies-apt::easybib'
 
+Chef::Log.info('!!! - This is deprecated! - !!! >>> ies-gearmand')
 package node['gearmand']['name']
 
 include_recipe 'gearmand::configure'

--- a/ies-gearmand/LICENSE
+++ b/ies-gearmand/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2016, Till Klampaeckel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ies-gearmand/README.md
+++ b/ies-gearmand/README.md
@@ -1,0 +1,42 @@
+# ies-gearmand-cookbook
+
+TODO: Enter the cookbook description here.
+
+## Supported Platforms
+
+TODO: List your supported platforms.
+
+## Attributes
+
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['ies-gearmand']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+## Usage
+
+### ies-gearmand::default
+
+Include `ies-gearmand` in your node's `run_list`:
+
+```json
+{
+  "run_list": [
+    "recipe[ies-gearmand::default]"
+  ]
+}
+```
+
+## License and Authors
+
+Author:: YOUR_NAME (<YOUR_EMAIL>)

--- a/ies-gearmand/README.md
+++ b/ies-gearmand/README.md
@@ -1,10 +1,10 @@
 # ies-gearmand-cookbook
 
-TODO: Enter the cookbook description here.
+A cookbook to install and configure gearmand from ondreij's PPA.
 
 ## Supported Platforms
 
-TODO: List your supported platforms.
+ - Ubuntu 14.04 and 16.04
 
 ## Attributes
 
@@ -16,10 +16,16 @@ TODO: List your supported platforms.
     <th>Default</th>
   </tr>
   <tr>
-    <td><tt>['ies-gearmand']['bacon']</tt></td>
-    <td>Boolean</td>
-    <td>whether to include bacon</td>
-    <td><tt>true</tt></td>
+    <td><tt>['ies-gearmand']['port']</tt></td>
+    <td>Int</td>
+    <td>The port to run gearman-job-server on</td>
+    <td><tt>31337</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['ies-gearmand']['log']</tt></td>
+    <td>String</td>
+    <td>Log arguments</td>
+    <td><tt>--syslog -l stderr</tt></td>
   </tr>
 </table>
 
@@ -39,4 +45,4 @@ Include `ies-gearmand` in your node's `run_list`:
 
 ## License and Authors
 
-Author:: YOUR_NAME (<YOUR_EMAIL>)
+Author:: Till Klampaeckel

--- a/ies-gearmand/attributes/default.rb
+++ b/ies-gearmand/attributes/default.rb
@@ -1,0 +1,2 @@
+default['ies-gearmand']['port'] = 31_337
+default['ies-gearmand']['log']  = '--syslog -l stderr' # or --logfile=/path/to/whatever

--- a/ies-gearmand/attributes/default.rb
+++ b/ies-gearmand/attributes/default.rb
@@ -1,2 +1,8 @@
 default['ies-gearmand']['port'] = 31_337
 default['ies-gearmand']['log']  = '--syslog -l stderr' # or --logfile=/path/to/whatever
+
+normal['php']['ppa'] = {
+  'name' => 'ondrejphp',
+  'package_prefix' => 'php5.6',
+  'uri' => 'ppa:ondrej/php'
+}

--- a/ies-gearmand/files/default/systemd.service
+++ b/ies-gearmand/files/default/systemd.service
@@ -8,6 +8,7 @@ PermissionsStartOnly=true
 User=gearman
 Restart=always
 PIDFile=/run/gearman/server.pid
+ExecStart=
 ExecStart=/usr/sbin/gearmand --pid-file=/run/gearman/server.pid $PARAMS
 
 [Install]

--- a/ies-gearmand/files/default/systemd.service
+++ b/ies-gearmand/files/default/systemd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=gearman job control server
+
+[Service]
+EnvironmentFile=-/etc/default/gearman-job-server
+ExecStartPre=/usr/bin/install -d -o gearman /run/gearman
+PermissionsStartOnly=true
+User=gearman
+Restart=always
+PIDFile=/run/gearman/server.pid
+ExecStart=/usr/sbin/gearmand --pid-file=/run/gearman/server.pid $PARAMS
+
+[Install]
+WantedBy=multi-user.target

--- a/ies-gearmand/files/default/upstart.conf
+++ b/ies-gearmand/files/default/upstart.conf
@@ -1,0 +1,15 @@
+# -*- upstart -*-
+
+# Upstart configuration script for "gearman-job-server".
+
+description "gearman job control server"
+
+start on (filesystem and net-device-up IFACE=lo)
+stop on runlevel [!2345]
+
+respawn
+
+script
+    . /etc/default/gearman-job-server
+    exec start-stop-daemon --start --chuid gearman --exec /usr/sbin/gearmand -- $PARAMS
+end script

--- a/ies-gearmand/files/default/upstart.conf
+++ b/ies-gearmand/files/default/upstart.conf
@@ -1,14 +1,3 @@
-# -*- upstart -*-
-
-# Upstart configuration script for "gearman-job-server".
-
-description "gearman job control server"
-
-start on (filesystem and net-device-up IFACE=lo)
-stop on runlevel [!2345]
-
-respawn
-
 script
     . /etc/default/gearman-job-server
     exec start-stop-daemon --start --chuid gearman --exec /usr/sbin/gearmand -- $PARAMS

--- a/ies-gearmand/metadata.rb
+++ b/ies-gearmand/metadata.rb
@@ -1,0 +1,12 @@
+name             'ies-gearmand'
+maintainer       'Till Klampaeckel'
+maintainer_email 'till@php.net'
+license          'Apache 2.0'
+description      'Installs/Configures ies-gearmand'
+long_description 'Installs/Configures ies-gearmand'
+version          '0.1.0'
+
+supports 'ubuntu'
+
+depends 'gearmand'
+depends 'php'

--- a/ies-gearmand/recipes/default.rb
+++ b/ies-gearmand/recipes/default.rb
@@ -1,8 +1,3 @@
-node.normal['php']['ppa'] = {
-  'name' => 'ondrejphp',
-  'uri' => 'ppa:ondrej/php'
-}
-
 package_name = 'gearman-job-server'
 
 include_recipe 'php::dependencies-ppa'

--- a/ies-gearmand/recipes/default.rb
+++ b/ies-gearmand/recipes/default.rb
@@ -1,0 +1,22 @@
+node.normal['php']['ppa'] = {
+  'name' => 'ondrejphp',
+  'uri' => 'ppa:ondrej/php'
+}
+
+package_name = 'gearman-job-server'
+
+include_recipe 'php::dependencies-ppa'
+include_recipe 'ies-gearmand::service'
+
+package package_name
+
+template "/etc/default/#{package_name}" do
+  mode   '0644'
+  cookbook 'gearmand'
+  source 'gearmand.default.erb'
+  variables(
+    :port => node['ies-gearmand']['port'],
+    :log  => node['ies-gearmand']['log']
+  )
+  notifies :restart, "service[#{package_name}]", :immediate
+end

--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -20,7 +20,7 @@ execute 'systemctl daemon-reload' do
   end
 end
 
-cookbook_file "/etc/init/#{name}.conf" do
+cookbook_file "/etc/init/#{name}.override" do
   source 'upstart.conf'
   owner 'root'
   group 'root'

--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -1,3 +1,34 @@
+service_provider = if Chef::VersionConstraint.new('>= 15.04').include?(node['platform_version'])
+                     Chef::Provider::Service::Systemd
+                   elsif Chef::VersionConstraint.new('>= 12.04').include?(node['platform_version'])
+                     Chef::Provider::Service::Upstart
+                   else
+                     service_provider = nil
+                   end
+
 service 'gearman-job-server' do
   action :nothing
+  provider service_provider
+end
+
+execute 'systemctl daemon-reload' do
+  action :nothing
+  only_if do
+    service_provider == Chef::Provider::Service::Systemd
+  end
+end
+
+cookbook_file '/etc/init/gearman-job-server.conf' do
+  source 'upstart.conf'
+  owner 'root'
+  group 'root'
+  mode 00644
+end
+
+cookbook_file '/lib/systemd/system/gearman-job-server.service' do
+  source 'systemd.service'
+  owner 'root'
+  group 'root'
+  mode 00644
+  notifies :run, 'execute[systemctl daemon-reload]', :immediate
 end

--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -1,0 +1,3 @@
+service 'gearman-job-server' do
+  action :nothing
+end

--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -6,7 +6,9 @@ service_provider = if Chef::VersionConstraint.new('>= 15.04').include?(node['pla
                      service_provider = nil
                    end
 
-service 'gearman-job-server' do
+name = 'gearman-job-server'
+
+service name do
   action :nothing
   provider service_provider
 end
@@ -18,14 +20,22 @@ execute 'systemctl daemon-reload' do
   end
 end
 
-cookbook_file '/etc/init/gearman-job-server.conf' do
+cookbook_file "/etc/init/#{name}.conf" do
   source 'upstart.conf'
   owner 'root'
   group 'root'
   mode 00644
 end
 
-cookbook_file '/lib/systemd/system/gearman-job-server.service' do
+systemd_override = "/etc/systemd/system/#{name}.service.d"
+
+directory systemd_override do
+  owner 'root'
+  group 'root'
+  recursive true
+end
+
+cookbook_file "#{systemd_override}/override.conf" do
   source 'systemd.service'
   owner 'root'
   group 'root'

--- a/ies-gearmand/spec/default_spec.rb
+++ b/ies-gearmand/spec/default_spec.rb
@@ -1,0 +1,48 @@
+require_relative 'spec_helper.rb'
+
+describe 'ies-gearmand::default' do
+  let(:runner) { ChefSpec::Runner.new }
+  let(:chef_run) { runner.converge(described_recipe) }
+  let(:node) { runner.node }
+
+  let(:default_file) { '/etc/default/gearman-job-server' }
+
+  describe 'standard flow' do
+    it 'discovers the ondreij repo' do
+      expect(chef_run.node['php']['ppa']).to eq({
+        'name' => 'ondrejphp',
+        'uri' => 'ppa:ondrej/php',
+        'package_prefix' => 'php5-easybib'
+      })
+
+      expect(chef_run).to include_recipe('php::dependencies-ppa')
+
+      expect(chef_run).to add_apt_repository('ondrejphp')
+        .with(
+          :uri => 'ppa:ondrej/php'
+        )
+    end
+
+    it 'installs gearman-job-server' do
+      expect(chef_run).to install_package('gearman-job-server')
+    end
+
+    it 'includes the service recipe' do
+      expect(chef_run).to include_recipe('ies-gearmand::service')
+    end
+
+    it 'installs defaults' do
+      expect(chef_run).to create_template(default_file)
+        .with(
+          :cookbook => 'gearmand',
+          :variables => {
+            :port => 31_337,
+            :log => '--syslog -l stderr'
+          }
+        )
+
+      resource = chef_run.template(default_file)
+      expect(resource).to notify('service[gearman-job-server]')
+    end
+  end
+end

--- a/ies-gearmand/spec/default_spec.rb
+++ b/ies-gearmand/spec/default_spec.rb
@@ -11,8 +11,8 @@ describe 'ies-gearmand::default' do
     it 'discovers the ondreij repo' do
       expect(chef_run.node['php']['ppa']).to eq({
         'name' => 'ondrejphp',
-        'uri' => 'ppa:ondrej/php',
-        'package_prefix' => 'php5-easybib'
+        'package_prefix' => 'php5.6',
+        'uri' => 'ppa:ondrej/php'
       })
 
       expect(chef_run).to include_recipe('php::dependencies-ppa')

--- a/ies-gearmand/spec/default_spec.rb
+++ b/ies-gearmand/spec/default_spec.rb
@@ -9,11 +9,9 @@ describe 'ies-gearmand::default' do
 
   describe 'standard flow' do
     it 'discovers the ondreij repo' do
-      expect(chef_run.node['php']['ppa']).to eq({
-        'name' => 'ondrejphp',
-        'package_prefix' => 'php5.6',
-        'uri' => 'ppa:ondrej/php'
-      })
+      expect(chef_run.node['php']['ppa']).to eq('name' => 'ondrejphp',
+                                                'package_prefix' => 'php5.6',
+                                                'uri' => 'ppa:ondrej/php')
 
       expect(chef_run).to include_recipe('php::dependencies-ppa')
 

--- a/ies-gearmand/spec/service_spec.rb
+++ b/ies-gearmand/spec/service_spec.rb
@@ -7,7 +7,8 @@ describe 'ies-gearmand::service' do
 
   describe 'standard flow' do
     it 'installs the config for systemd' do
-      expect(chef_run).to create_cookbook_file('/lib/systemd/system/gearman-job-server.service')
+      expect(chef_run).to create_directory('/etc/systemd/system/gearman-job-server.service.d')
+      expect(chef_run).to create_cookbook_file('/etc/systemd/system/gearman-job-server.service.d/override.conf')
     end
 
     it 'installs the config for upstart' do
@@ -15,7 +16,7 @@ describe 'ies-gearmand::service' do
     end
 
     it 'notifies systemd to daemon-reload' do
-      resource = chef_run.cookbook_file('/lib/systemd/system/gearman-job-server.service')
+      resource = chef_run.cookbook_file('/etc/systemd/system/gearman-job-server.service.d/override.conf')
       expect(resource).to notify('execute[systemctl daemon-reload]')
     end
   end

--- a/ies-gearmand/spec/service_spec.rb
+++ b/ies-gearmand/spec/service_spec.rb
@@ -12,7 +12,7 @@ describe 'ies-gearmand::service' do
     end
 
     it 'installs the config for upstart' do
-      expect(chef_run).to create_cookbook_file('/etc/init/gearman-job-server.conf')
+      expect(chef_run).to create_cookbook_file('/etc/init/gearman-job-server.override')
     end
 
     it 'notifies systemd to daemon-reload' do

--- a/ies-gearmand/spec/service_spec.rb
+++ b/ies-gearmand/spec/service_spec.rb
@@ -1,0 +1,22 @@
+require_relative 'spec_helper.rb'
+
+describe 'ies-gearmand::service' do
+  let(:runner) { ChefSpec::Runner.new }
+  let(:chef_run) { runner.converge(described_recipe) }
+  let(:node) { runner.node }
+
+  describe 'standard flow' do
+    it 'installs the config for systemd' do
+      expect(chef_run).to create_cookbook_file('/lib/systemd/system/gearman-job-server.service')
+    end
+
+    it 'installs the config for upstart' do
+      expect(chef_run).to create_cookbook_file('/etc/init/gearman-job-server.conf')
+    end
+
+    it 'notifies systemd to daemon-reload' do
+      resource = chef_run.cookbook_file('/lib/systemd/system/gearman-job-server.service')
+      expect(resource).to notify('execute[systemctl daemon-reload]')
+    end
+  end
+end

--- a/ies-gearmand/spec/spec_helper.rb
+++ b/ies-gearmand/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'chefspec'
+
+RSpec.configure do |c|
+  c.platform = 'ubuntu'
+  c.version = '14.04'
+  c.log_level = :error
+end

--- a/vagrant-test/php/Vagrantfile
+++ b/vagrant-test/php/Vagrantfile
@@ -1,4 +1,4 @@
-ENV['recipe_runlist'] = 'stack-easybib::role-phpapp'
+ENV['recipe_runlist'] = 'stack-easybib::role-phpapp,php::module-gearman,ies-gearmand'
 ENV['chef_json'] = "#{File.dirname(__FILE__)}/deploy.json"
 
 require_relative '../vagrant-provision'


### PR DESCRIPTION
# Changes

 - new `ies-gearmand` cookbook
 - eventually replaces/phases out `gearmand`
 - required in order to be able to update to the ondreij repo for PHP (lib conflicts, missing links otherwise with ondreij's Gearman extension vs. our gearmand server package)

# CR

 - I included a test setup for 16.04
 - once merged, I'll rebase #1119 to test with `www-vagrant`
 - please update the stable PR post-merge

Related: easybib/ops#218
