### PR TITLE
Fix: fix tideways install with ondreij php

### DIFF
--- a/tideways/metadata.rb
+++ b/tideways/metadata.rb
@@ -5,4 +5,5 @@ license 'BSD-2-Clause'
 description 'Install and configure tideways daemon and PHP extension'
 
 depends 'apt'
+depends 'php'
 depends 'php-fpm'

--- a/tideways/recipes/configure.rb
+++ b/tideways/recipes/configure.rb
@@ -23,8 +23,31 @@ template '/etc/default/tideways-daemon' do
   notifies :restart, 'service[tideways-daemon]'
 end
 
+execute 'phpenmod -s ALL -v ALL tideways' do
+  not_if do
+    node['php']['ppa']['package_prefix'] == 'php5-easybib'
+  end
+end
+
+{
+  '/usr/lib/php/20121212/' => 5.5,
+  '/usr/lib/php/20131226/' => 5.6,
+  '/usr/lib/php/20151012/' => 7.0,
+  '/usr/lib/php/20160303/' => 7.1
+}.each do |php_api_path, php_version|
+  link "#{php_api_path}/tideways.so" do
+    to "/usr/lib/tideways/tideways-php-#{php_version}.so"
+    not_if do
+      node['php']['ppa']['package_prefix'] == 'php5-easybib'
+    end
+  end
+end
+
 template "#{node['php-fpm']['prefix']}/etc/php/tideways.ini" do
   source 'tideways.ini.erb'
   mode 0644
   notifies :reload, 'service[php-fpm]', :delayed
+  only_if do
+
+  end
 end

--- a/vagrant-test/php/Vagrantfile
+++ b/vagrant-test/php/Vagrantfile
@@ -1,4 +1,4 @@
-ENV['recipe_runlist'] = 'stack-easybib::role-phpapp,php::module-gearman,ies-gearmand'
+ENV['recipe_runlist'] = 'stack-easybib::role-phpapp,php::module-gearman,ies-gearmand,tideways'
 ENV['chef_json'] = "#{File.dirname(__FILE__)}/deploy.json"
 
 require_relative '../vagrant-provision'


### PR DESCRIPTION
# Changes

Fixes `tideways-php` to work with ondreij's PPA. 

 * symlink .so's into all directories
 * ensure .ini files get installed into all dirs (using `phpenmod`)


# CR

 - I ran `vagrant-test/php` and `php -m` contained tideways
 - please update the stable PR post-merge

Related: #1119