### PR TITLE
Backwards-compatible changes for Chef12

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,8 +61,8 @@ task :foodcritic, [:cookbook] do |t, args|
   args.with_defaults(:cookbook => nil)
 
   if Gem::Version.new('1.9.2') <= Gem::Version.new(RUBY_VERSION.dup)
-    epic_fail = %w( )
-    ignore_rules = %w( FC059 )
+    epic_fail = %w()
+    ignore_rules = %w(FC059)
 
     cb = if args.cookbook.nil?
            find_cookbooks('.').join(' ')

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,8 @@ task :unittest, :cookbook do |t, args|
                        else
                          "#{args.cookbook}/**/tests/test_*.rb"
                        end
+    raketask.verbose = false
+    raketask.warning = false
   end
   task('testtask').execute
 end

--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task :foodcritic, [:cookbook] do |t, args|
 
   if Gem::Version.new('1.9.2') <= Gem::Version.new(RUBY_VERSION.dup)
     epic_fail = %w( )
-    ignore_rules = %w( )
+    ignore_rules = %w( FC059 )
 
     cb = if args.cookbook.nil?
            find_cookbooks('.').join(' ')

--- a/apache-couchdb/metadata.rb
+++ b/apache-couchdb/metadata.rb
@@ -5,6 +5,8 @@ license           'BSD License'
 description       'Setup Apache CouchDB'
 version           '0.1'
 recipe            'apache-couchdb::default', 'Installs Apache CouchDB'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/apache-couchdb/spec/monitoring_spec.rb
+++ b/apache-couchdb/spec/monitoring_spec.rb
@@ -24,7 +24,7 @@ describe 'apache-couchdb::configure' do
 
   describe 'setup monitoring' do
     before do
-      node.set['apache-couchdb']['monitoring'] = {
+      node.override['apache-couchdb']['monitoring'] = {
         'user' => 'monitoring',
         'pass' => 'test123'
       }

--- a/apache-solr/metadata.rb
+++ b/apache-solr/metadata.rb
@@ -5,5 +5,7 @@ license           'BSD License'
 description       'Setup Apache Solr'
 version           '0.1'
 recipe            'apache-solr::default', 'Installs Apache Solr'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/apt-spy2/metadata.rb
+++ b/apt-spy2/metadata.rb
@@ -5,6 +5,8 @@ license          'New BSD license'
 description      'Installs apt-spy2'
 version          '0.1'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+source_url 'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url 'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/aptly/metadata.rb
+++ b/aptly/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Aptly mirror launchpad'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/avahi/metadata.rb
+++ b/avahi/metadata.rb
@@ -5,6 +5,8 @@ license           'BSD License'
 description       'Installs and configures avahi daemon'
 version           '0.1'
 recipe            'avahi::default', 'Installs avahi'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/awscli/metadata.rb
+++ b/awscli/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Cookbook to install awscli'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/bash/metadata.rb
+++ b/bash/metadata.rb
@@ -5,6 +5,8 @@ license          'New BSD license'
 description      'Configures bash environments'
 version          '0.1'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/bibcd/metadata.rb
+++ b/bibcd/metadata.rb
@@ -2,6 +2,8 @@ name              'bibcd'
 maintainer        'Florian Holzhauer'
 maintainer_email  'fh-cookbookzgalorealsocats@holzhauer.it'
 version          '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'easybib'
 supports 'ubuntu'

--- a/bower/metadata.rb
+++ b/bower/metadata.rb
@@ -2,6 +2,8 @@ name              'bower'
 maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 license  'BSD License'

--- a/composer/metadata.rb
+++ b/composer/metadata.rb
@@ -3,3 +3,5 @@ maintainer       'Till Klampaeckel'
 maintainer_email 'till@php.net'
 version          '0.2'
 license          'BSD License'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)

--- a/composer/spec/configure_spec.rb
+++ b/composer/spec/configure_spec.rb
@@ -28,7 +28,7 @@ describe 'composer::configure' do
 
   describe 'configure/empty OAuth2 token' do
     before do
-      node.set['composer']['environment'] = {
+      node.override['composer']['environment'] = {
         'user' => 'root',
         'group' => 'root'
       }
@@ -44,12 +44,12 @@ describe 'composer::configure' do
 
   describe 'configure' do
     before do
-      node.set['composer']['environment'] = {
+      node.override['composer']['environment'] = {
         'user' => 'www-data',
         'group' => 'www-data'
       }
 
-      node.set['composer']['oauth_key'] = oauth
+      node.override['composer']['oauth_key'] = oauth
 
       Dir.stub(:home) { '/var/www' }
     end

--- a/dhcp3/metadata.rb
+++ b/dhcp3/metadata.rb
@@ -6,5 +6,7 @@ description       "DHCP3 configuration - this is to 'inject' a DNScache into the
 version           '0.1'
 recipe            'dhcp3::configure', 'Setup a custom DNS server (currently hardcoded to 127.0.0.1)'
 recipe            'dhcp3::service', 'Wrap the init.d script.'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/dnsmasq/metadata.rb
+++ b/dnsmasq/metadata.rb
@@ -5,5 +5,7 @@ license           'BSD License'
 description       'Install a local DNS cache.'
 version           '0.1'
 recipe            'dnsmasq::default', 'Install and configure the DNS cache.'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/docker/metadata.rb
+++ b/docker/metadata.rb
@@ -4,6 +4,8 @@ license           'BSD'
 maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu', '12.04.2'
 

--- a/easybib-deploy/metadata.rb
+++ b/easybib-deploy/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Deploys easybib'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/easybib-deploy/spec/ssl-certificates_spec.rb
+++ b/easybib-deploy/spec/ssl-certificates_spec.rb
@@ -17,12 +17,12 @@ describe 'easybib-deploy::ssl-certificates' do
   let(:dummy_cert) { '-----BEGIN CERTIFICATE-----[...]-----END CERTIFICATE-----' }
 
   before do
-    node.set['ssl-deploy']['ssl-role']  = ssl_role
-    node.set['ssl-deploy']['directory'] = ssl_dir
-    node.set['opsworks']['instance']['layers'] = ssl_role # for allow_deploy
-    node.set['deploy'][ssl_role]['ssl_certificate']     = dummy_cert
-    node.set['deploy'][ssl_role]['ssl_certificate_key'] = dummy_key
-    node.set['deploy'][ssl_role]['ssl_certificate_ca']  = dummy_cert
+    node.override['ssl-deploy']['ssl-role']  = ssl_role
+    node.override['ssl-deploy']['directory'] = ssl_dir
+    node.override['opsworks']['instance']['layers'] = ssl_role # for allow_deploy
+    node.override['deploy'][ssl_role]['ssl_certificate']     = dummy_cert
+    node.override['deploy'][ssl_role]['ssl_certificate_key'] = dummy_key
+    node.override['deploy'][ssl_role]['ssl_certificate_ca']  = dummy_cert
   end
 
   describe 'everything set should create all certs completely' do
@@ -57,7 +57,7 @@ describe 'easybib-deploy::ssl-certificates' do
 
   describe 'another app is being deployed' do
     before do
-      node.set['ssl-deploy']['ssl-role']  = 'whatever'
+      node.override['ssl-deploy']['ssl-role']  = 'whatever'
     end
 
     it 'does not attempt to create ssl directoy' do
@@ -70,7 +70,7 @@ describe 'easybib-deploy::ssl-certificates' do
 
   describe 'ssl app without certificate key' do
     before do
-      node.set['deploy'][ssl_role]['ssl_certificate_key'] = ''
+      node.override['deploy'][ssl_role]['ssl_certificate_key'] = ''
     end
 
     it 'does not attempt to create ssl directoy' do
@@ -81,7 +81,7 @@ describe 'easybib-deploy::ssl-certificates' do
 
   describe 'ssl certificates should work without intermediate ca set' do
     before do
-      node.set['deploy'][ssl_role]['ssl_certificate_ca'] = nil
+      node.override['deploy'][ssl_role]['ssl_certificate_ca'] = nil
     end
 
     it 'does create combined certificate without intermediate ca' do

--- a/easybib/metadata.rb
+++ b/easybib/metadata.rb
@@ -6,6 +6,8 @@ description       "Tools we'd like on all servers."
 version           '0.1'
 recipe            'easybib::awscommand', "Installs Timothy Kay's aws command"
 recipe            'easybib::nginxstats', 'Script to show current stats.'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/easybib/spec/easybib_deploy_manager_spec.rb
+++ b/easybib/spec/easybib_deploy_manager_spec.rb
@@ -27,7 +27,7 @@ describe 'easybib_deploy_manager' do
 
   context 'no deployments' do
     before do
-      node.set['deploy'] = {}
+      node.override['deploy'] = {}
     end
 
     it 'logs when no applications are configured' do
@@ -39,7 +39,7 @@ describe 'easybib_deploy_manager' do
 
     context 'apps but no deploy' do
       before do
-        node.set['fixtures']['applications'] = {
+        node.override['fixtures']['applications'] = {
           :app_number_one => {},
           :app_number_two => {}
         }
@@ -58,7 +58,7 @@ describe 'easybib_deploy_manager' do
 
   context 'deployments' do
     before do
-      node.set['deploy'] = {
+      node.override['deploy'] = {
         :app_number_one => {
           :deploy_to => '/var/www/app1',
           :document_root => 'www',
@@ -71,7 +71,7 @@ describe 'easybib_deploy_manager' do
         }
       }
 
-      node.set['fixtures']['applications'] = {
+      node.override['fixtures']['applications'] = {
         :app_number_one => {
           :layer => 'app-server',
           :nginx => 'silex.erb.conf'
@@ -82,7 +82,7 @@ describe 'easybib_deploy_manager' do
         }
       }
 
-      node.set['opsworks'] = {
+      node.override['opsworks'] = {
         :instance => {
           :layers => ['app-server']
         },
@@ -111,7 +111,7 @@ describe 'easybib_deploy_manager' do
 
     context 'deploys an app with extended cookbook/nginx conf' do
       before do
-        node.set['fixtures']['applications'] = {
+        node.override['fixtures']['applications'] = {
           :app_number_one => {
             :layer => 'app-server',
             :nginx => {

--- a/easybib/spec/easybib_sslcertificate_spec.rb
+++ b/easybib/spec/easybib_sslcertificate_spec.rb
@@ -32,7 +32,7 @@ describe 'easybib_sslcertificate' do
       fake_deploy['ssl_certificate']     = ssl_cert
       fake_deploy['ssl_certificate_key'] = ssl_key
 
-      node.set['fake_deploy'] = fake_deploy
+      node.override['fake_deploy'] = fake_deploy
     end
 
     it 'invokes the provider' do
@@ -69,7 +69,7 @@ describe 'easybib_sslcertificate' do
       fake_deploy['ssl_certificate']     = '/tmp/example.org.pem'
       fake_deploy['ssl_certificate_key'] = '/tmp/example.org.key'
 
-      node.set['fake_deploy'] = fake_deploy
+      node.override['fake_deploy'] = fake_deploy
     end
 
     it 'creates the files with the correct content' do

--- a/easybib/spec/easybib_supervisor-without-matching-role_spec.rb
+++ b/easybib/spec/easybib_supervisor-without-matching-role_spec.rb
@@ -24,7 +24,7 @@ describe 'easybib_supervisor-without-matching-role' do
     describe 'create' do
       before do
         stub_supervisor_with_two_services
-        node.set['opsworks'] = {} # to have is_aws true
+        node.override['opsworks'] = {} # to have is_aws true
       end
 
       it 'does not proceed' do
@@ -58,8 +58,8 @@ describe 'easybib_supervisor-without-matching-role-implicit' do
     describe 'create' do
       before do
         stub_supervisor_with_two_services
-        node.set['opsworks']['instance']['layers'] = %w(role1 role2)
-        node.set['easybib_deploy']['supervisor_role'] = 'some-other-role'
+        node.override['opsworks']['instance']['layers'] = %w(role1 role2)
+        node.override['easybib_deploy']['supervisor_role'] = 'some-other-role'
       end
 
       it 'does not proceed' do

--- a/easybib/spec/easybib_supervisor_create_with_orphan_spec.rb
+++ b/easybib/spec/easybib_supervisor_create_with_orphan_spec.rb
@@ -24,7 +24,7 @@ describe 'easybib_supervisor - create new service with orphan service' do
     describe 'create' do
       before do
         stub_supervisor_with_one_service_and_one_orphan
-        node.set['opsworks'] = {} # to have is_aws true
+        node.override['opsworks'] = {} # to have is_aws true
 
       end
 

--- a/easybib/spec/easybib_supervisor_disable_spec.rb
+++ b/easybib/spec/easybib_supervisor_disable_spec.rb
@@ -27,7 +27,7 @@ describe 'easybib_supervisor - disable' do
     describe 'delete' do
       before do
         stub_supervisor_with_one_service
-        node.set['opsworks'] = {} # to have is_aws true
+        node.override['opsworks'] = {} # to have is_aws true
       end
 
       it 'deletes all supervisors' do

--- a/easybib/spec/easybib_supervisor_spec.rb
+++ b/easybib/spec/easybib_supervisor_spec.rb
@@ -24,7 +24,7 @@ describe 'easybib_supervisor - explicit attrs' do
     describe 'create' do
       before do
         stub_supervisor_with_two_services
-        node.set['opsworks'] = {} # to have is_aws true
+        node.override['opsworks'] = {} # to have is_aws true
       end
 
       it 'enables the first service' do
@@ -83,8 +83,8 @@ describe 'easybib_supervisor - implicit attrs' do
     describe 'create' do
       before do
         stub_supervisor_with_two_services
-        node.set['opsworks']['instance']['layers'] = %w(role1 role2)
-        node.set['easybib_deploy']['supervisor_role'] = 'role1'
+        node.override['opsworks']['instance']['layers'] = %w(role1 role2)
+        node.override['easybib_deploy']['supervisor_role'] = 'role1'
       end
 
       it 'enables the first service' do
@@ -110,7 +110,7 @@ describe 'easybib_supervisor - implicit attrs' do
     describe 'create' do
       before do
         stub_supervisor_with_two_services
-        node.set['easybib_deploy']['supervisor_role'] = 'role1'
+        node.override['easybib_deploy']['supervisor_role'] = 'role1'
       end
 
       it 'enables the first service' do
@@ -136,8 +136,8 @@ describe 'easybib_supervisor - implicit attrs' do
     describe 'create' do
       before do
         stub_supervisor_does_not_exist
-        node.set['opsworks']['instance']['layers'] = %w(role1 role2)
-        node.set['easybib_deploy']['supervisor_role'] = 'role1'
+        node.override['opsworks']['instance']['layers'] = %w(role1 role2)
+        node.override['easybib_deploy']['supervisor_role'] = 'role1'
       end
 
       it 'does not proceed' do

--- a/easybib/tests/test_config.rb
+++ b/easybib/tests/test_config.rb
@@ -9,7 +9,7 @@ class TestEasyBibConfig < Test::Unit::TestCase
 
   def test_config_no_doublequote
     fake_node = Chef::Node.new
-    fake_node.set['fakeapp']['env']['database']['something'] = 'foo"bar'
+    fake_node.override['fakeapp']['env']['database']['something'] = 'foo"bar'
     assert_raises RuntimeError do
       ::EasyBib::Config.get_env('nginx', 'fakeapp', fake_node)
     end
@@ -17,15 +17,15 @@ class TestEasyBibConfig < Test::Unit::TestCase
 
   def test_get_vagrant_appdir
     fake_node = Chef::Node.new
-    fake_node.set['vagrant']['applications']['app']['app_root_location'] = '/app/root/dir/'
-    fake_node.set['vagrant']['applications']['app']['doc_root_location'] = '/foo/bla/dir/www/'
+    fake_node.override['vagrant']['applications']['app']['app_root_location'] = '/app/root/dir/'
+    fake_node.override['vagrant']['applications']['app']['doc_root_location'] = '/foo/bla/dir/www/'
     assert_equal(
       '/app/root/dir/',
       ::EasyBib::Config.get_appdata(fake_node, 'app', 'app_dir')
     )
 
     fake_node = Chef::Node.new
-    fake_node.set['vagrant']['applications']['app']['doc_root_location'] = '/doc/root/dir/'
+    fake_node.override['vagrant']['applications']['app']['doc_root_location'] = '/doc/root/dir/'
     assert_equal(
       '/doc/root/',
       ::EasyBib::Config.get_appdata(fake_node, 'app', 'app_dir')
@@ -34,28 +34,28 @@ class TestEasyBibConfig < Test::Unit::TestCase
 
   def test_get_domains
     fake_node = Chef::Node.new
-    fake_node.set['vagrant']['applications']['app']['domain_name'] = 'whatever.local'
+    fake_node.override['vagrant']['applications']['app']['domain_name'] = 'whatever.local'
     assert_equal(
       'whatever.local',
       ::EasyBib::Config.get_domains(fake_node, 'app')
     )
 
     fake_node = Chef::Node.new
-    fake_node.set['vagrant']['applications']['app']['domain_name'] = ['whatever.local', 'thing.local']
+    fake_node.override['vagrant']['applications']['app']['domain_name'] = ['whatever.local', 'thing.local']
     assert_equal(
       'whatever.local thing.local',
       ::EasyBib::Config.get_domains(fake_node, 'app')
     )
 
     fake_node = Chef::Node.new
-    fake_node.set['deploy']['app']['domains'] = ['whatever.local', 'thing.local']
+    fake_node.override['deploy']['app']['domains'] = ['whatever.local', 'thing.local']
     assert_equal(
       'whatever.local thing.local',
       ::EasyBib::Config.get_domains(fake_node, 'app')
     )
 
     fake_node = Chef::Node.new
-    fake_node.set['foo']['domain']['app'] = 'bla.local'
+    fake_node.override['foo']['domain']['app'] = 'bla.local'
     assert_equal(
       'bla.local',
       ::EasyBib::Config.get_domains(fake_node, 'app', 'foo')
@@ -64,7 +64,7 @@ class TestEasyBibConfig < Test::Unit::TestCase
 
   def test_ini_config
     fake_node = Chef::Node.new
-    fake_node.set['fakeapp']['env']['database'] = {
+    fake_node.override['fakeapp']['env']['database'] = {
       'something' => 'foobar',
       'whatever' => 'bar'
     }
@@ -99,7 +99,7 @@ BLA_SOMEARRAY[1] = \"server2\"\n",
     # IMPORTANT: Do not use port as string, since we want to check if no
     # Fixnum to string error happens
     fake_node = get_fakenode_config
-    fake_node.set['deploy']['some_app']['database'] = {
+    fake_node.override['deploy']['some_app']['database'] = {
       'type' => 'mysql',
       'host' => 'some.db.tld',
       'username' => 'dbuser',
@@ -171,7 +171,7 @@ fastcgi_param BLA_SOMEARRAY[1] \"server2\";\n",
 
   def test_config_to_nginx_empty_settings
     fake_node = Chef::Node.new
-    fake_node.set['deploy'] = {
+    fake_node.override['deploy'] = {
       'some_app' => {
         'application' => 'some_app',
         'domains' => ['foo.tld', 'bar.tld'],
@@ -180,8 +180,8 @@ fastcgi_param BLA_SOMEARRAY[1] \"server2\";\n",
       }
     }
 
-    fake_node.set['opsworks'] =  { 'stack' => { 'name' => 'opsworks-stack' } }
-    fake_node.set['easybib_deploy'] =  { 'envtype' => 'playground' }
+    fake_node.override['opsworks'] =  { 'stack' => { 'name' => 'opsworks-stack' } }
+    fake_node.override['easybib_deploy'] =  { 'envtype' => 'playground' }
 
     assert_equal("fastcgi_param DEPLOYED_APPLICATION_APPNAME \"some_app\";
 fastcgi_param DEPLOYED_APPLICATION_DOMAINS \"foo.tld bar.tld\";
@@ -196,15 +196,15 @@ fastcgi_param DEPLOYED_STACK_STACKNAME \"opsworks-stack\";\n",
 
   def test_config_vagrantenv
     fake_node = Chef::Node.new
-    fake_node.set['deploy'] = {
+    fake_node.override['deploy'] = {
       'some_app' => {
         'application' => 'some_app',
         'domains' => ['foo.tld', 'bar.tld']
       }
     }
 
-    fake_node.set['vagrant'] =  { 'applications' => { 'some_app' => { 'app_root_location' => '/some_path', 'doc_root_location' => '/some_path/foo' } } }
-    fake_node.set['easybib_deploy'] =  { 'envtype' => 'playground' }
+    fake_node.override['vagrant'] =  { 'applications' => { 'some_app' => { 'app_root_location' => '/some_path', 'doc_root_location' => '/some_path/foo' } } }
+    fake_node.override['easybib_deploy'] =  { 'envtype' => 'playground' }
 
     assert_equal("fastcgi_param DEPLOYED_APPLICATION_APPNAME \"some_app\";
 fastcgi_param DEPLOYED_APPLICATION_DOMAINS \"foo.tld bar.tld\";
@@ -262,7 +262,7 @@ export BLA_SOMEARRAY[1]=\"server2\"\n",
 
   def get_fakenode_config
     fake_node = Chef::Node.new
-    fake_node.set['deploy'] = {
+    fake_node.override['deploy'] = {
       'some_app' => {
         'application' => 'some_app',
         'domains' => ['foo.tld', 'bar.tld'],
@@ -270,7 +270,7 @@ export BLA_SOMEARRAY[1]=\"server2\"\n",
         'document_root' => 'www'
       }
     }
-    fake_node.set['some_app'] = {
+    fake_node.override['some_app'] = {
       'env' => {
         'bla' => {
           'somekey' => 'somevalue',
@@ -282,31 +282,31 @@ export BLA_SOMEARRAY[1]=\"server2\"\n",
       }
     }
 
-    fake_node.set['opsworks'] =  { 'stack' => { 'name' => 'opsworks-stack' } }
-    fake_node.set['easybib_deploy'] =  { 'envtype' => 'playground' }
+    fake_node.override['opsworks'] =  { 'stack' => { 'name' => 'opsworks-stack' } }
+    fake_node.override['easybib_deploy'] =  { 'envtype' => 'playground' }
 
     fake_node
   end
 
   def get_fakenode_redundant_config
     fake_node = Chef::Node.new
-    fake_node.set['deploy']['some_app'] = {
+    fake_node.override['deploy']['some_app'] = {
       'application' => 'some_app',
       'domains' => ['foo.tld', 'bar.tld'],
       'deploy_to' => '/tmp/bla',
       'document_root' => 'www'
     }
-    fake_node.set['some_app']['env']['bla'] = {
+    fake_node.override['some_app']['env']['bla'] = {
       'somekey' => 'somevalue',
       'somegroup' => {
         'someotherkey' => 'someothervalue'
       },
       'somearray' => %w(server1 server2)
     }
-    fake_node.set['some_stack']['env']['stackvalue']['somekey'] = 'somevalue'
-    fake_node.set['some_stack']['env']['bla']['somekey'] = 'this-should-not-be-here'
-    fake_node.set['opsworks']['stack']['name'] = 'some_stack'
-    fake_node.set['easybib_deploy']['envtype'] = 'playground'
+    fake_node.override['some_stack']['env']['stackvalue']['somekey'] = 'somevalue'
+    fake_node.override['some_stack']['env']['bla']['somekey'] = 'this-should-not-be-here'
+    fake_node.override['opsworks']['stack']['name'] = 'some_stack'
+    fake_node.override['easybib_deploy']['envtype'] = 'playground'
 
     fake_node
   end

--- a/easybib/tests/test_config_node.rb
+++ b/easybib/tests/test_config_node.rb
@@ -8,8 +8,8 @@ class TestEasyBibConfig < Test::Unit::TestCase
 
   def test_get_from_stack
     fake_node = Chef::Node.new
-    fake_node.set['value'] = 'content'
-    fake_node.set['foo']['bar']['bla']['batz'] = 'thing'
+    fake_node.override['value'] = 'content'
+    fake_node.override['foo']['bar']['bla']['batz'] = 'thing'
     assert_equal(
       'thing',
       ::EasyBib::Config.node(fake_node, 'app', 'foo', 'bar', 'bla', 'batz')
@@ -22,10 +22,10 @@ class TestEasyBibConfig < Test::Unit::TestCase
 
   def test_get_for_app
     fake_node = Chef::Node.new
-    fake_node.set['value'] = 'content'
-    fake_node.set['foo']['bar']['bla']['batz'] = 'thing'
-    fake_node.set['app']['value'] = 'app-content'
-    fake_node.set['app']['foo']['bar']['bla']['batz'] = 'app-thing'
+    fake_node.override['value'] = 'content'
+    fake_node.override['foo']['bar']['bla']['batz'] = 'thing'
+    fake_node.override['app']['value'] = 'app-content'
+    fake_node.override['app']['foo']['bar']['bla']['batz'] = 'app-thing'
     assert_equal(
       'app-thing',
       ::EasyBib::Config.node(fake_node, 'app', 'foo', 'bar', 'bla', 'batz')

--- a/easybib/tests/test_deploy.rb
+++ b/easybib/tests/test_deploy.rb
@@ -19,9 +19,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
   def test_allow_deploy_wrong_environment_rejections
     # "allow_deploy should never deploy if [easybib][cluster_name] does not match the stack name"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['some-layer']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-other-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['some-layer']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-other-name'
 
     assert_equal(
       false,
@@ -30,9 +30,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
 
     # "allow_deploy should never deploy requested_role is not a layer in the stack"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['some-layer']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['some-layer']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       false,
@@ -43,9 +43,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
   def test_allow_deploy_valid_singleapp_deploys
     # "allow_deploy should use app name as default layer name"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['app']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['app']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       true,
@@ -54,9 +54,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
 
     # "allow_deploy with custom layer name"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['some-layer']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['some-layer']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       true,
@@ -67,9 +67,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
   def test_allow_deploy_with_multiple_apps
     # "allow_deploy with multiple app names, all wrong"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['app']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['app']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       false,
@@ -78,9 +78,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
 
     # "allow_deploy with multiple app names, one correct"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['app']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['app']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       true,
@@ -89,9 +89,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
 
     # "allow_deploy should raise an error with wrong vartype for requested app"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['app']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['app']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_raise RuntimeError do
       allow_deploy('app', { 'app' => 'bar-app' }, nil, fake_node)
@@ -101,9 +101,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
   def test_allow_deploy_multilayer
     # "allow_deploy with multiple app names, one correct, and multiple layers"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['some-layer']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['some-layer']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       true,
@@ -112,9 +112,9 @@ class TestEasyBibDeploy < Test::Unit::TestCase
 
     # "allow_deploy with multiple app names, one correct, and multiple layers"
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['instance']['layers'] = ['no-such-layer']
-    fake_node.set['opsworks']['stack']['name'] = 'some-name'
-    fake_node.set['easybib']['cluster_name'] = 'some-name'
+    fake_node.override['opsworks']['instance']['layers'] = ['no-such-layer']
+    fake_node.override['opsworks']['stack']['name'] = 'some-name'
+    fake_node.override['easybib']['cluster_name'] = 'some-name'
 
     assert_equal(
       false,

--- a/easybib/tests/test_easybib.rb
+++ b/easybib/tests/test_easybib.rb
@@ -28,7 +28,7 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_normalized_cluster_name
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['stack']['name'] = 'EasyBib Playgr$und-123'
+    fake_node.override['opsworks']['stack']['name'] = 'EasyBib Playgr$und-123'
 
     assert_equal(
       'easybib_playgr_und-123',

--- a/easybib/tests/test_ppa.rb
+++ b/easybib/tests/test_ppa.rb
@@ -14,22 +14,22 @@ class TestEasyBib < Test::Unit::TestCase
       use_aptly_mirror?(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'precise'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['lsb']['codename'] = 'precise'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       false,
       use_aptly_mirror?(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = false
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = false
     assert_equal(
       false,
       use_aptly_mirror?(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       true,
       use_aptly_mirror?(fake_node)
@@ -38,13 +38,13 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_php_mirror_repo_url
     fake_node = Chef::Node.new
-    fake_node.set['easybib']['php_mirror_version'] = '55'
+    fake_node.override['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php55',
       php_mirror_repo_url(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['easybib']['php_mirror_version'] = '56'
+    fake_node.override['easybib']['php_mirror_version'] = '56'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php56',
       php_mirror_repo_url(fake_node)
@@ -58,30 +58,30 @@ class TestEasyBib < Test::Unit::TestCase
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'precise'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['lsb']['codename'] = 'precise'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       'http://something.com',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = false
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = false
     assert_equal(
       'http://something.com',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
     assert_equal(
       'http://ppa.ezbib.com/mirrors/remote-mirrors',
       ppa_mirror(fake_node, 'http://something.com')
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
-    fake_node.set['easybib']['php_mirror_version'] = '56'
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['easybib']['php_mirror_version'] = '56'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/remote-mirrors',
       ppa_mirror(fake_node, 'http://something.com')
@@ -90,30 +90,30 @@ class TestEasyBib < Test::Unit::TestCase
 
   def test_php_ppa_mirror
     fake_node = Chef::Node.new
-    fake_node.set['easybib']['php_mirror_version'] = '55'
+    fake_node.override['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'ppa:easybib/php55',
       ppa_mirror(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['easybib']['enable_ppa_mirror'] = false
-    fake_node.set['easybib']['php_mirror_version'] = '55'
+    fake_node.override['easybib']['enable_ppa_mirror'] = false
+    fake_node.override['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'ppa:easybib/php55',
       ppa_mirror(fake_node, 'ppa:easybib/php55')
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
-    fake_node.set['easybib']['php_mirror_version'] = '55'
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['easybib']['php_mirror_version'] = '55'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php55',
       ppa_mirror(fake_node)
     )
     fake_node = Chef::Node.new
-    fake_node.set['lsb']['codename'] = 'trusty'
-    fake_node.set['easybib']['enable_ppa_mirror'] = true
-    fake_node.set['easybib']['php_mirror_version'] = '56'
+    fake_node.override['lsb']['codename'] = 'trusty'
+    fake_node.override['easybib']['enable_ppa_mirror'] = true
+    fake_node.override['easybib']['php_mirror_version'] = '56'
     assert_equal(
       'http://ppa.ezbib.com/mirrors/php56',
       ppa_mirror(fake_node)

--- a/easybib/tests/test_sns.rb
+++ b/easybib/tests/test_sns.rb
@@ -21,7 +21,7 @@ class TestEasyBibSns < Test::Unit::TestCase
 
   def test_does_send_sns
     fake_node = get_fake_node
-    fake_node.set['easybib']['sns']['topic_arn'] = 'foobar'
+    fake_node.override['easybib']['sns']['topic_arn'] = 'foobar'
 
     assert_equal(true, sns_notify_spinup(fake_node, FakeSNS.new))
   end
@@ -30,9 +30,9 @@ class TestEasyBibSns < Test::Unit::TestCase
 
   def get_fake_node
     fake_node = Chef::Node.new
-    fake_node.set['opsworks']['stack']['name'] = 'unittest'
-    fake_node.set['opsworks']['instance']['hostname'] = 'localhost-test'
-    fake_node.set['easybib']['sns']['notify_spinup'] = '-test'
+    fake_node.override['opsworks']['stack']['name'] = 'unittest'
+    fake_node.override['opsworks']['instance']['hostname'] = 'localhost-test'
+    fake_node.override['easybib']['sns']['notify_spinup'] = '-test'
 
     fake_node
   end

--- a/easybib_vagrant/metadata.rb
+++ b/easybib_vagrant/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'See README.md'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/elasticsearch/metadata.rb
+++ b/elasticsearch/metadata.rb
@@ -6,5 +6,7 @@ description       'Setup Elasticsearch'
 version           '0.1'
 recipe            'elasticsearch::default', 'Installs elasticsearch'
 recipe            'elasticsearch::service', 'Service definitions for elasticsearch'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/ezproxy/metadata.rb
+++ b/ezproxy/metadata.rb
@@ -5,5 +5,7 @@ license           'BSD License'
 description       'Installs the EzProxy proxy server.'
 version           '0.1'
 recipe            'ezproxy::server', 'Installs EzProxy'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/fail2ban/metadata.rb
+++ b/fail2ban/metadata.rb
@@ -4,7 +4,8 @@ maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs and configures fail2ban'
 version           '2.2.1'
-
+source_url 'https://github.com/chef-cookbooks/fail2ban' if respond_to?(:source_url)
+issues_url 'https://github.com/chef-cookbooks/fail2ban/issues' if respond_to?(:issues_url)
 recipe 'fail2ban', 'Installs and configures fail2ban'
 
 %w(debian ubuntu).each do |os|

--- a/fake-s3/metadata.rb
+++ b/fake-s3/metadata.rb
@@ -1,6 +1,10 @@
 name 'fake-s3'
 
 supports 'ubuntu'
-
+maintainer        'Till Klampaeckel'
+maintainer_email  'till@php.net'
+version           '0.1'
 depends 'easybib'
 depends 'supervisor'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)

--- a/fake-sqs/metadata.rb
+++ b/fake-sqs/metadata.rb
@@ -1,6 +1,11 @@
 name 'fake-sqs'
 
 supports 'ubuntu'
+maintainer        'Till Klampaeckel'
+maintainer_email  'till@php.net'
+version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'easybib'
 depends 'supervisor'

--- a/gearmand/metadata.rb
+++ b/gearmand/metadata.rb
@@ -8,3 +8,5 @@ supports 'ubuntu'
 depends 'ies-apt'
 depends 'monit'
 license           'BSD License'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)

--- a/haproxy/metadata.rb
+++ b/haproxy/metadata.rb
@@ -10,3 +10,5 @@ depends 'ies-letsencrypt'
 depends 'ies-ssl'
 
 license 'BSD License'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)

--- a/haproxy/spec/backend_forwarding-backends_spec.rb
+++ b/haproxy/spec/backend_forwarding-backends_spec.rb
@@ -3,12 +3,12 @@ require_relative 'spec_helper.rb'
 describe 'haproxy::configure' do
   let(:runner) do
     ChefSpec::Runner.new do |node|
-      node.set[:opsworks][:stack][:name] = 'chefspec'
-      node.set[:opsworks][:instance][:region][:id] = 'local'
-      node.set[:opsworks][:layers][:nginxphpapp][:instances] = {}
-      node.set[:opsworks][:layers][:app1][:instances] = {}
-      node.set[:opsworks][:layers][:app2][:instances] = {}
-      node.set[:haproxy] = {
+      node.override[:opsworks][:stack][:name] = 'chefspec'
+      node.override[:opsworks][:instance][:region][:id] = 'local'
+      node.override[:opsworks][:layers][:nginxphpapp][:instances] = {}
+      node.override[:opsworks][:layers][:app1][:instances] = {}
+      node.override[:opsworks][:layers][:app2][:instances] = {}
+      node.override[:haproxy] = {
         :acls => {},
         :forwarding_layers => {
           :app2 => {

--- a/haproxy/spec/backend_healthcheck_spec.rb
+++ b/haproxy/spec/backend_healthcheck_spec.rb
@@ -3,12 +3,12 @@ require_relative 'spec_helper.rb'
 describe 'haproxy::configure' do
   let(:runner) do
     ChefSpec::Runner.new do |node|
-      node.set[:opsworks][:stack][:name] = 'chefspec'
-      node.set[:opsworks][:instance][:region][:id] = 'local'
-      node.set[:opsworks][:layers][:nginxphpapp][:instances] = {}
-      node.set[:opsworks][:layers][:app1][:instances] = {}
-      node.set[:opsworks][:layers][:app2][:instances] = {}
-      node.set[:haproxy] = {
+      node.override[:opsworks][:stack][:name] = 'chefspec'
+      node.override[:opsworks][:instance][:region][:id] = 'local'
+      node.override[:opsworks][:layers][:nginxphpapp][:instances] = {}
+      node.override[:opsworks][:layers][:app1][:instances] = {}
+      node.override[:opsworks][:layers][:app2][:instances] = {}
+      node.override[:haproxy] = {
         :acls => {},
         :additional_layers => {
           :app1 => {

--- a/haproxy/spec/ctl_spec.rb
+++ b/haproxy/spec/ctl_spec.rb
@@ -3,7 +3,7 @@ require_relative 'spec_helper.rb'
 describe 'haproxy::ctl' do
   let(:runner) do
     ChefSpec::Runner.new do |node|
-      node.set[:opsworks][:layers][:nginxphpapp][:instances] = {}
+      node.override[:opsworks][:layers][:nginxphpapp][:instances] = {}
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }
@@ -12,9 +12,9 @@ describe 'haproxy::ctl' do
 
   describe 'standard settings' do
     before do
-      node.set['opsworks']['stack']['name'] = 'Amazing Stack'
-      node.set['haproxy']['ctl']['statsd']['host'] = 'foo.example.com'
-      node.set['haproxy']['ctl']['statsd']['port'] = '23'
+      node.override['opsworks']['stack']['name'] = 'Amazing Stack'
+      node.override['haproxy']['ctl']['statsd']['host'] = 'foo.example.com'
+      node.override['haproxy']['ctl']['statsd']['port'] = '23'
     end
 
     it 'installs haproxyctl' do

--- a/haproxy/spec/ssl_spec.rb
+++ b/haproxy/spec/ssl_spec.rb
@@ -2,20 +2,20 @@ require_relative 'spec_helper.rb'
 
 describe 'haproxy::configure' do
   let(:runner) do
-    ChefSpec::Runner.new do |node|
-      node.set[:opsworks][:stack][:name] = 'chefspec'
-      node.set[:opsworks][:instance][:region][:id] = 'local'
-      node.set[:opsworks][:layers][:nginxphpapp][:instances] = {
+    ChefSpec::SoloRunner.new do |node|
+      node.override[:opsworks][:stack][:name] = 'chefspec'
+      node.override[:opsworks][:instance][:region][:id] = 'local'
+      node.override[:opsworks][:layers][:nginxphpapp][:instances] = {
         'php-app-server-1' => {
           'private_dns_name' => 'php.app.server.1.tld'
         }
       }
-      node.set[:opsworks][:layers][:nodeapp][:instances] = {
+      node.override[:opsworks][:layers][:nodeapp][:instances] = {
         'node-app-server-1' => {
           'private_dns_name' => 'node.app.server.1.tld'
         }
       }
-      node.set[:haproxy] = {
+      node.override[:haproxy] = {
         :ssl => 'on',
         :websocket_layers => {
           :nodeapp => {
@@ -49,7 +49,7 @@ describe 'haproxy::configure' do
 
     describe 'only' do
       before do
-        node.set[:haproxy][:ssl] = 'only'
+        node.override[:haproxy][:ssl] = 'only'
       end
 
       it 'redirects all http to https' do
@@ -62,7 +62,7 @@ describe 'haproxy::configure' do
 
     describe 'disabled' do
       before do
-        node.set[:haproxy][:ssl] = 'off'
+        node.override[:haproxy][:ssl] = 'off'
       end
 
       it 'does not bind to 443' do

--- a/haproxy/spec/ssl_spec.rb
+++ b/haproxy/spec/ssl_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper.rb'
 
 describe 'haproxy::configure' do
   let(:runner) do
-    ChefSpec::SoloRunner.new do |node|
+    ChefSpec::Runner.new do |node|
       node.override[:opsworks][:stack][:name] = 'chefspec'
       node.override[:opsworks][:instance][:region][:id] = 'local'
       node.override[:opsworks][:layers][:nginxphpapp][:instances] = {

--- a/haproxy/spec/websocket_spec.rb
+++ b/haproxy/spec/websocket_spec.rb
@@ -3,14 +3,14 @@ require_relative 'spec_helper.rb'
 describe 'haproxy::configure' do
   let(:runner) do
     ChefSpec::Runner.new do |node|
-      node.set[:opsworks][:stack][:name] = 'chefspec'
-      node.set[:opsworks][:instance][:region][:id] = 'local'
-      node.set[:opsworks][:layers][:nginxphpapp][:instances] = {
+      node.override[:opsworks][:stack][:name] = 'chefspec'
+      node.override[:opsworks][:instance][:region][:id] = 'local'
+      node.override[:opsworks][:layers][:nginxphpapp][:instances] = {
         'php-app-server-1' => {
           'private_dns_name' => 'php.app.server.1.tld'
         }
       }
-      node.set[:opsworks][:layers][:nodeapp][:instances] = {
+      node.override[:opsworks][:layers][:nodeapp][:instances] = {
         'node-app-server-1' => {
           'private_dns_name' => 'node.app.server.1.tld'
         },
@@ -18,7 +18,7 @@ describe 'haproxy::configure' do
           'private_dns_name' => 'node.app.server.2.tld'
         }
       }
-      node.set[:haproxy] = {
+      node.override[:haproxy] = {
         :websocket_layers => {
           :nodeapp => {
             :port => 8123,

--- a/ies-apt/metadata.rb
+++ b/ies-apt/metadata.rb
@@ -7,6 +7,8 @@ version           '0.0.1'
 recipe            'ies-apt::proxy', 'Set up an APT proxy'
 recipe            'ies-apt::ppa', 'Setup the tools needed to initialize PPAs'
 recipe            'ies-apt::repair', 'Install apt-repair-sources'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 %w(ubuntu).each do |os|
   supports os

--- a/ies-chef-handler-sns/metadata.rb
+++ b/ies-chef-handler-sns/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'bwiborg@chegg.com'
 license           'Apache 2.0'
 description       'Wrapper around chef_handler_sns'
 version           '0.0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 %w(ubuntu).each do |os|
   supports os

--- a/ies-chef-handler-sns/spec/default_spec.rb
+++ b/ies-chef-handler-sns/spec/default_spec.rb
@@ -4,7 +4,7 @@ describe 'ies-chef-handler-sns::default' do
   let(:topic_arn) { 'arn:aws:sns:us-east-1:12341234:MyTopicName' }
   let(:chef_run) do
     ChefSpec::Runner.new(:step_into => ['chef_sns_handler']) do |node|
-      node.set['chef_handler_sns']['topic_arn'] = topic_arn
+      node.override['chef_handler_sns']['topic_arn'] = topic_arn
     end.converge(described_recipe)
   end
 

--- a/ies-gearmand/metadata.rb
+++ b/ies-gearmand/metadata.rb
@@ -5,6 +5,8 @@ license          'Apache 2.0'
 description      'Installs/Configures ies-gearmand'
 long_description 'Installs/Configures ies-gearmand'
 version          '0.1.0'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/ies-letsencrypt/metadata.rb
+++ b/ies-letsencrypt/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'Apache-2.0'
 description       'Install letsencrypt'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/ies-letsencrypt/spec/certbot_spec.rb
+++ b/ies-letsencrypt/spec/certbot_spec.rb
@@ -7,7 +7,7 @@ describe 'ies-letsencrypt::certbot' do
 
   describe 'standard settings' do
     before do
-      node.set['ies-letsencrypt']['certbot']['bin'] = '/foo/cb'
+      node.override['ies-letsencrypt']['certbot']['bin'] = '/foo/cb'
     end
 
     it 'installs certbot-auto' do

--- a/ies-letsencrypt/spec/renewal_spec.rb
+++ b/ies-letsencrypt/spec/renewal_spec.rb
@@ -13,14 +13,14 @@ describe 'ies-letsencrypt::renewal' do
 
   describe 'domains configured' do
     before do
-      node.set['ies-letsencrypt']['domains'] = [
+      node.override['ies-letsencrypt']['domains'] = [
         'example.org',
         'secure.example.org'
       ]
-      node.set['ies-letsencrypt']['certbot']['bin'] = '/opt/le/certbot'
-      node.set['ies-letsencrypt']['certbot']['cron'] = '/opt/le/cron'
-      node.set['ies-letsencrypt']['certbot']['port'] = 31_337
-      node.set['ies-letsencrypt']['ssl_dir'] = '/home/till/ssl'
+      node.override['ies-letsencrypt']['certbot']['bin'] = '/opt/le/certbot'
+      node.override['ies-letsencrypt']['certbot']['cron'] = '/opt/le/cron'
+      node.override['ies-letsencrypt']['certbot']['port'] = 31_337
+      node.override['ies-letsencrypt']['ssl_dir'] = '/home/till/ssl'
     end
 
     it 'has an initial setup command to get certificates' do

--- a/ies-letsencrypt/spec/setup_spec.rb
+++ b/ies-letsencrypt/spec/setup_spec.rb
@@ -7,7 +7,7 @@ describe 'ies-letsencrypt::setup' do
 
   describe 'setup' do
     before do
-      node.set['sysop_email'] = 'bofh@example.org'
+      node.override['sysop_email'] = 'bofh@example.org'
     end
 
     it 'creates the ssl dir' do

--- a/ies-mysql-tuning-primer/metadata.rb
+++ b/ies-mysql-tuning-primer/metadata.rb
@@ -4,5 +4,7 @@ maintainer_email  'bwiborg@chegg.com'
 license           'BSD/2'
 description       'Install customized MySQL Tuning-Primer'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/ies-mysql/metadata.rb
+++ b/ies-mysql/metadata.rb
@@ -1,7 +1,11 @@
 name 'ies-mysql'
 
 description 'A wrapper recipe to install and configure MySQL Server and client.'
-
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
+maintainer        'Till Klampaeckel'
+maintainer_email  'till@php.net'
+version           '0.1'
 supports 'ubuntu'
 
 depends 'mysql'

--- a/ies-mysql/spec/dev_spec.rb
+++ b/ies-mysql/spec/dev_spec.rb
@@ -17,7 +17,7 @@ describe 'ies-mysql::dev' do
 
   describe 'MySQL 5.7' do
     before do
-      node.set['ies-mysql']['version'] = '5.7'
+      node.override['ies-mysql']['version'] = '5.7'
     end
 
     it 'renders new grants' do
@@ -27,7 +27,7 @@ describe 'ies-mysql::dev' do
 
   describe 'AWS' do
     before do
-      node.set['opsworks'] = {}
+      node.override['opsworks'] = {}
     end
 
     it 'it does not execute the recipe' do

--- a/ies-rbenv/metadata.rb
+++ b/ies-rbenv/metadata.rb
@@ -4,5 +4,7 @@ maintainer_email  'brian.wiborg@imagineeasy.com'
 license           'BSD 2-clause'
 description       'ImagineEasySolutions - Ruby Provider Collection'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/ies-route53/metadata.rb
+++ b/ies-route53/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Wrapper for working with the Route53 cookbook.'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/ies-route53/spec/add_spec.rb
+++ b/ies-route53/spec/add_spec.rb
@@ -13,7 +13,7 @@ describe 'ies-route53::add' do
   describe 'AWS' do
     before do
       # mock OpsWorks
-      node.set['opsworks'] = {
+      node.override['opsworks'] = {
         'instance' => {
           'hostname' => 'spec',
           'region' => 'local',
@@ -33,7 +33,7 @@ describe 'ies-route53::add' do
 
     describe 'add' do
       before do
-        node.set['ies-route53']['zone'] = {
+        node.override['ies-route53']['zone'] = {
           'ttl' => 1,
           'id' => 'foo',
           'custom_access_key' => 'access-key',
@@ -57,7 +57,7 @@ describe 'ies-route53::add' do
 
     describe 'credential auto discovery' do
       before do
-        node.set['ies-route53']['zone'] = {
+        node.override['ies-route53']['zone'] = {
           'ttl' => 2,
           'id' => 'bar'
         }

--- a/ies-ssl/metadata.rb
+++ b/ies-ssl/metadata.rb
@@ -4,5 +4,7 @@ maintainer_email  'till@php.net'
 license           'Apache-2.0'
 description       'Create self-signed certificates'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/ies-zsh/metadata.rb
+++ b/ies-zsh/metadata.rb
@@ -4,5 +4,7 @@ maintainer_email  'brian.wiborg@imagineeasy.com'
 license           'BSD 2-clause'
 description       'Helper cookbook for making zsh bootstrap-phase Bash-compliant.'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/ies/metadata.rb
+++ b/ies/metadata.rb
@@ -6,6 +6,8 @@ description       'Our generic setup and install scripts across all stacks'
 version           '0.1'
 recipe            'ies::role-generic', 'Generic setup for all our instances'
 recipe            'ies::setup-sns', 'Set up SNS notifications for our instances'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/java/metadata.rb
+++ b/java/metadata.rb
@@ -3,3 +3,5 @@ maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 version           '0.1'
 license           'BSD License'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)

--- a/memcache/metadata.rb
+++ b/memcache/metadata.rb
@@ -3,3 +3,5 @@ maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 version           '0.1'
 license           'BSD License'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)

--- a/monit/metadata.rb
+++ b/monit/metadata.rb
@@ -3,6 +3,8 @@ maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 version           '0.1'
 license           'BSD License'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'easybib'
 depends 'nginx-app'

--- a/newrelic/metadata.rb
+++ b/newrelic/metadata.rb
@@ -2,6 +2,8 @@ name              'newrelic'
 maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/newrelic/spec/plugin_haproxy_spec.rb
+++ b/newrelic/spec/plugin_haproxy_spec.rb
@@ -29,8 +29,8 @@ describe 'haproxy::plugin_newrelic' do
       }
     }
 
-    chef_run.node.set['haproxy'] = haproxy_node
-    chef_run.node.set['newrelic'] = newrelic_node
+    chef_run.node.override['haproxy'] = haproxy_node
+    chef_run.node.override['newrelic'] = newrelic_node
 
     chef_run.converge 'newrelic::plugin_haproxy'
     expect(chef_run).to install_gem_package 'bundler'

--- a/nginx-amplify/spec/configure_spec.rb
+++ b/nginx-amplify/spec/configure_spec.rb
@@ -24,8 +24,8 @@ describe 'nginx-amplify::configure' do
 
   describe 'api_key' do
     before do
-      node.set['nginx-amplify']['api_key'] = 'super-secret'
-      node.set['nginx-amplify']['hostname'] = 'box.example.org'
+      node.override['nginx-amplify']['api_key'] = 'super-secret'
+      node.override['nginx-amplify']['hostname'] = 'box.example.org'
     end
 
     it 'installs the uuid helper' do

--- a/nginx-amplify/spec/default_spec.rb
+++ b/nginx-amplify/spec/default_spec.rb
@@ -24,7 +24,7 @@ describe 'nginx-amplify::default' do
     end
 
     it 'installs a specific version of the agent' do
-      node.set['nginx-amplify']['version'] = '0.23-1'
+      node.override['nginx-amplify']['version'] = '0.23-1'
       expect(chef_run).to install_package('nginx-amplify-agent').with(:version => '0.23-1')
     end
 

--- a/nginx-app/metadata.rb
+++ b/nginx-app/metadata.rb
@@ -6,6 +6,8 @@ description       'Installs and configures an nginx for our appservers.'
 version           '0.1'
 recipe            'nginx-app::server', 'Installs Nginx'
 recipe            'nginx-app::configure', 'Configures virtualhost, etc.'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'rsyslogd'
 depends 'php-fpm'

--- a/nginx-app/spec/redirector_spec.rb
+++ b/nginx-app/spec/redirector_spec.rb
@@ -17,7 +17,7 @@ describe 'nginx-app::redirector' do
 
   describe 'setup domain redirect' do
     before do
-      node.set['redirector']['domains'] = {
+      node.override['redirector']['domains'] = {
         'example.org' => 'example.com'
       }
     end
@@ -39,7 +39,7 @@ describe 'nginx-app::redirector' do
 
   describe 'setup single url redirect' do
     before do
-      node.set['redirector']['urls'] = {
+      node.override['redirector']['urls'] = {
         'john-doe.example.org' => {
           '/' => 'example.com'
         }
@@ -65,7 +65,7 @@ describe 'nginx-app::redirector' do
 
   describe "ssl with let's encrypt" do
     before do
-      node.set['redirector']['ssl'] = {
+      node.override['redirector']['ssl'] = {
         'example.org' => 'http://www.something.de',
         'foo.example.org' => 'http://else.com'
       }

--- a/nginx-app/spec/silex-template_spec.rb
+++ b/nginx-app/spec/silex-template_spec.rb
@@ -16,7 +16,7 @@ describe 'silex-config-template' do
 
   describe 'enabled access log' do
     before do
-      node.set['testdata']['access_log'] = '/tmp.log'
+      node.override['testdata']['access_log'] = '/tmp.log'
     end
 
     it 'sets correct access log path' do
@@ -26,8 +26,8 @@ describe 'silex-config-template' do
 
   describe 'no routes enabled or disabled' do
     before do
-      node.set['testdata']['routes_enabled'] = nil
-      node.set['testdata']['routes_denied']  = nil
+      node.override['testdata']['routes_enabled'] = nil
+      node.override['testdata']['routes_denied']  = nil
     end
 
     it 'does not deny any routes' do
@@ -60,9 +60,9 @@ describe 'silex-config-template' do
 
   describe 'some routes enabled' do
     before do
-      node.set['testdata']['routes_enabled'] = ['/some/route', '/other/route']
-      node.set['testdata']['routes_denied']  = nil
-      node.set['opsworks']['stack']['name']  = 'rspec'
+      node.override['testdata']['routes_enabled'] = ['/some/route', '/other/route']
+      node.override['testdata']['routes_denied']  = nil
+      node.override['opsworks']['stack']['name']  = 'rspec'
     end
 
     it 'does set routes for enabled routes' do
@@ -88,9 +88,9 @@ describe 'silex-config-template' do
 
   describe 'some routes enabled including slash' do
     before do
-      node.set['testdata']['routes_enabled'] = ['/some/route', '/other/route', '/']
-      node.set['testdata']['routes_denied']  = nil
-      node.set['opsworks']['stack']['name']  = 'rspec'
+      node.override['testdata']['routes_enabled'] = ['/some/route', '/other/route', '/']
+      node.override['testdata']['routes_denied']  = nil
+      node.override['opsworks']['stack']['name']  = 'rspec'
     end
 
     it 'does not redirect / to another location' do
@@ -101,8 +101,8 @@ describe 'silex-config-template' do
 
   describe 'some routes disabled' do
     before do
-      node.set['testdata']['routes_enabled'] = nil
-      node.set['testdata']['routes_denied']  = ['/some/route', '/other/route']
+      node.override['testdata']['routes_enabled'] = nil
+      node.override['testdata']['routes_denied']  = ['/some/route', '/other/route']
     end
 
     it 'does not deny any routes' do
@@ -123,9 +123,9 @@ describe 'silex-config-template' do
 
   describe 'some routes enabled, some disabled' do
     before do
-      node.set['testdata']['routes_enabled'] = ['/some/route', '/other/route']
-      node.set['testdata']['routes_denied']  = ['/some/droute', '/other/droute']
-      node.set['opsworks']['stack']['name']  = 'rspec'
+      node.override['testdata']['routes_enabled'] = ['/some/route', '/other/route']
+      node.override['testdata']['routes_denied']  = ['/some/droute', '/other/droute']
+      node.override['opsworks']['stack']['name']  = 'rspec'
     end
 
     it 'does set routes for enabled routes' do

--- a/ops/metadata.rb
+++ b/ops/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'ops infrastructure roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/pecl-manager/metadata.rb
+++ b/pecl-manager/metadata.rb
@@ -3,6 +3,8 @@ maintainer        'Till Klampaeckel'
 maintainer_email  'till@php.net'
 license           'BSD License'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/php-fpm/metadata.rb
+++ b/php-fpm/metadata.rb
@@ -10,6 +10,8 @@ recipe            'php-fpm::prepare', 'Creates prequesites like user and directo
 recipe            'php-fpm::dependencies', 'Install dependencies'
 recipe            'php-fpm::ohai', 'php-fpm ohai plugin installer'
 recipe            'php-fpm::monit', 'php-fpm monit monitoring'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/php-fpm/spec/cloudwatch_spec.rb
+++ b/php-fpm/spec/cloudwatch_spec.rb
@@ -7,13 +7,13 @@ describe 'php-fpm::cloudwatch' do
   let(:cronscript_name) { "#{node['php-fpm']['prefix']}/bin/phpfpm-cloudwatch.sh" }
 
   before do
-    node.set['opsworks']['stack']['name'] = 'Stack'
-    node.set['opsworks']['instance']['hostname'] = 'host'
+    node.override['opsworks']['stack']['name'] = 'Stack'
+    node.override['opsworks']['instance']['hostname'] = 'host'
   end
 
   describe 'cloudwatch enabled' do
     before do
-      node.set['php-fpm']['cloudwatch'] = true
+      node.override['php-fpm']['cloudwatch'] = true
     end
 
     it 'creates cronjob script' do
@@ -33,7 +33,7 @@ describe 'php-fpm::cloudwatch' do
 
   describe 'cloudwatch disabled' do
     before do
-      node.set['php-fpm']['cloudwatch'] = false
+      node.override['php-fpm']['cloudwatch'] = false
     end
 
     it 'does not create cronjob script' do

--- a/php-fpm/spec/configure_spec.rb
+++ b/php-fpm/spec/configure_spec.rb
@@ -22,8 +22,8 @@ describe 'php-fpm::configure' do
 
   describe 'pool configuration' do
     before do
-      node.set['php-fpm']['pools'] = %w(app1 app2 app3)
-      node.set['php-fpm']['max_children'] = 99
+      node.override['php-fpm']['pools'] = %w(app1 app2 app3)
+      node.override['php-fpm']['max_children'] = 99
     end
 
     it 'creates three pool configurations' do
@@ -55,7 +55,7 @@ describe 'php-fpm::configure' do
 
     describe 'update-alternatives' do
       before do
-        node.set['php']['ppa']['package_prefix'] = 'php8.5'
+        node.override['php']['ppa']['package_prefix'] = 'php8.5'
       end
 
       it 'runs update-alternatives' do

--- a/php-fpm/spec/default_spec.rb
+++ b/php-fpm/spec/default_spec.rb
@@ -27,7 +27,7 @@ describe 'php-fpm::default' do
 
   describe 'php.ini refactoring' do
     before do
-      node.set['php-fpm']['packages'] = 'php5-easybib-soap,php5-easybib-tidy'
+      node.override['php-fpm']['packages'] = 'php5-easybib-soap,php5-easybib-tidy'
     end
 
     it 'includes module recipes for soap & tidy' do

--- a/php-pear/metadata.rb
+++ b/php-pear/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Installs various PEAR packages'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'php'
 depends 'php-fpm'

--- a/php/attributes/default.rb
+++ b/php/attributes/default.rb
@@ -5,6 +5,8 @@ default['php']['ppa']['package_prefix'] = 'php5-easybib'
 default['php']['extensions']['config_dir'] = 'etc/php'
 default['php']['extensions']['ini_suffix'] = '-settings'
 
+default['php-aws-elasticache']['settings'] = {}
+
 default['php-apc'] = {}
 # custom prefix for package: php-apcu, instead of php5.6-apcu
 default['php-apc']['package_prefix'] = nil
@@ -59,6 +61,8 @@ default['php-phar']['load_priority'] = nil
 default['amazon-elasticache-cluster-client'] = {
   'php_version' => '7.0'
 }
+
+default['php-poppler']['settings'] = {}
 
 default['poppler'] = {}
 default['poppler']['package_uri'] = 'https://packagecloud.io/till/poppler-backport/ubuntu/'

--- a/php/metadata.rb
+++ b/php/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 version           '0.1'
 license           'BSD License'
 supports          'ubuntu'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'apt'
 depends 'aptly'

--- a/php/recipes/module-aws_elasticache_cluster_client.rb
+++ b/php/recipes/module-aws_elasticache_cluster_client.rb
@@ -3,6 +3,7 @@ include_recipe 'php::dependencies-ppa'
 ext = 'amazon-elasticache-cluster-client.so'
 
 source_version = node['amazon-elasticache-cluster-client']['php_version']
+module_config = node['php-aws-elasticache']['settings']
 
 php_pecl ext do
   prefix node['php-fpm']['exec_prefix']
@@ -11,7 +12,7 @@ php_pecl ext do
 end
 
 php_config File.basename(ext, '.so') do
-  config {}
+  config module_config
   config_dir node['php']['extensions']['config_dir']
   extension_path ext
   load_extension true

--- a/php/recipes/module-poppler-pdf.rb
+++ b/php/recipes/module-poppler-pdf.rb
@@ -14,7 +14,7 @@ end
 
 ext = 'poppler.so'
 php_config File.basename(ext, '.so') do
-  config {}
+  config node['php-poppler']['settings']
   config_dir node['php']['extensions']['config_dir']
   extension_path ext
   load_extension true

--- a/php/spec/etc_spec.rb
+++ b/php/spec/etc_spec.rb
@@ -14,14 +14,14 @@ describe 'php::module-apc' do
   # The following should serve as an example of what is required to correctly setup
   # PHP7.0 etc. or so from ondrej's launchpad PPA
   before do
-    node.set['php']['extensions']['config_dir'] = 'etc/php/7.0/mods-available'
-    node.set['php']['ppa'] = {
+    node.override['php']['extensions']['config_dir'] = 'etc/php/7.0/mods-available'
+    node.override['php']['ppa'] = {
       'name' => 'ondrejphp',
       'uri' => 'ppa:ondrej/php',
       'package_prefix' => 'php7.0'
     }
-    node.set['php-apc']['package_prefix'] = 'php'
-    node.set['php-fpm'] = {
+    node.override['php-apc']['package_prefix'] = 'php'
+    node.override['php-fpm'] = {
       'prefix' => '',
       'exec_prefix' => '/usr',
       'fpm_config' => 'etc/php/7.0/fpm/php.ini',

--- a/php/spec/module-apc_spec.rb
+++ b/php/spec/module-apc_spec.rb
@@ -52,7 +52,7 @@ describe 'php::module-apc' do
 
   describe 'with load_priority set' do
     before do
-      node.set['php-apc']['load_priority'] = 99
+      node.override['php-apc']['load_priority'] = 99
     end
     it 'does not create soap-settings.ini without load_priority' do
       expect(chef_run).to_not render_file('/opt/easybib/etc/php/apc-settings.ini')
@@ -64,7 +64,7 @@ describe 'php::module-apc' do
 
   describe 'custom prefix' do
     before do
-      node.set['php-apc']['package_prefix'] = 'php-special'
+      node.override['php-apc']['package_prefix'] = 'php-special'
     end
 
     it 'installs the php-special-apcu module' do

--- a/php/spec/module-aws_elasticache_cluster_client_spec.rb
+++ b/php/spec/module-aws_elasticache_cluster_client_spec.rb
@@ -14,13 +14,13 @@ describe 'php::module-aws_elasticache_cluster_client' do
   let(:my_config) { double(Php::Config) }
 
   before do
-    node.set['php']['extensions']['config_dir'] = 'etc/php/7.0/mods-available'
-    node.set['php']['ppa'] = {
+    node.override['php']['extensions']['config_dir'] = 'etc/php/7.0/mods-available'
+    node.override['php']['ppa'] = {
       'name' => 'ondrejphp',
       'uri' => 'ppa:ondrej/php',
       'package_prefix' => 'php7.0'
     }
-    node.set['php-fpm'] = {
+    node.override['php-fpm'] = {
       'prefix' => '',
       'exec_prefix' => '/usr',
       'fpm_config' => 'etc/php/7.0/fpm/php.ini',

--- a/php/spec/module-opcache_spec.rb
+++ b/php/spec/module-opcache_spec.rb
@@ -11,7 +11,7 @@ describe 'php::module-opcache' do
     let(:error_log) { '/some/path/file.log' }
 
     before do
-      node.set['php-opcache']['settings']['error_log'] = 'BLA'
+      node.override['php-opcache']['settings']['error_log'] = 'BLA'
     end
 
     it 'adds ppa mirror configuration' do

--- a/php/spec/module-poppler-pdf_spec.rb
+++ b/php/spec/module-poppler-pdf_spec.rb
@@ -4,10 +4,10 @@ describe 'php::module-poppler-pdf' do
 
   let(:chef_run) do
     ChefSpec::Runner.new do |node|
-      node.set['poppler']['package_uri'] = 'http://foo.bar/package'
-      node.set['poppler']['package_distro'] = 'trusty'
-      node.set['poppler']['package_components'] = ['main']
-      node.set['poppler']['package_key_uri'] = 'keyfile.gpg'
+      node.override['poppler']['package_uri'] = 'http://foo.bar/package'
+      node.override['poppler']['package_distro'] = 'trusty'
+      node.override['poppler']['package_components'] = ['main']
+      node.override['poppler']['package_key_uri'] = 'keyfile.gpg'
     end.converge(described_recipe)
   end
 

--- a/php/spec/module-soap_spec.rb
+++ b/php/spec/module-soap_spec.rb
@@ -11,8 +11,8 @@ describe 'php::module-soap' do
   let(:chef_run) { runner.converge(described_recipe) }
 
   before do
-    node.set['php']['ppa']['package_prefix'] = 'php5.6'
-    node.set['php-fpm']['tmpdir'] = '/tmp/chefspec/php'
+    node.override['php']['ppa']['package_prefix'] = 'php5.6'
+    node.override['php-fpm']['tmpdir'] = '/tmp/chefspec/php'
   end
 
   it 'adds ppa mirror configuration' do
@@ -42,7 +42,7 @@ describe 'php::module-soap' do
 
   describe 'with load_priority set' do
     before do
-      node.set['php-soap']['load_priority'] = 99
+      node.override['php-soap']['load_priority'] = 99
     end
     it 'does not create soap-settings.ini without load_priority' do
       expect(chef_run).to_not render_file('/opt/easybib/etc/php/soap-settings.ini')

--- a/php/spec/module-tidy_spec.rb
+++ b/php/spec/module-tidy_spec.rb
@@ -7,8 +7,8 @@ describe 'php::module-tidy' do
   let(:chef_run) { runner.converge(described_recipe) }
 
   before do
-    node.set['php']['ppa']['package_prefix'] = 'php5.6'
-    node.set['php-fpm']['tmpdir'] = '/tmp/chefspec/php'
+    node.override['php']['ppa']['package_prefix'] = 'php5.6'
+    node.override['php-fpm']['tmpdir'] = '/tmp/chefspec/php'
   end
 
   it 'adds ppa mirror configuration' do

--- a/php/spec/provider-config_spec.rb
+++ b/php/spec/provider-config_spec.rb
@@ -45,8 +45,8 @@ describe 'php_config' do
 
   describe 'load_extension standard path' do
     before do
-      node.set['config-spec']['extension_path'] = '/some/path.extension.so'
-      node.set['config-spec']['load_extension'] = true
+      node.override['config-spec']['extension_path'] = '/some/path.extension.so'
+      node.override['config-spec']['load_extension'] = true
     end
 
     it 'loads the extension without zend prefix' do
@@ -70,9 +70,9 @@ describe 'php_config' do
 
   describe 'load_extension zend extension' do
     before do
-      node.set['config-spec']['extension_path'] = '/some/path.extension.so'
-      node.set['config-spec']['load_extension'] = true
-      node.set['config-spec']['zend_extension'] = true
+      node.override['config-spec']['extension_path'] = '/some/path.extension.so'
+      node.override['config-spec']['load_extension'] = true
+      node.override['config-spec']['zend_extension'] = true
     end
 
     it 'loads the extension with zend prefix' do
@@ -96,9 +96,9 @@ describe 'php_config' do
 
   describe 'extension set but load false' do
     before do
-      node.set['config-spec']['extension_path'] = '/some/path.extension.so'
-      node.set['config-spec']['load_extension'] = false
-      node.set['config-spec']['zend_extension'] = true
+      node.override['config-spec']['extension_path'] = '/some/path.extension.so'
+      node.override['config-spec']['load_extension'] = false
+      node.override['config-spec']['zend_extension'] = true
     end
 
     it 'does not load the extension' do
@@ -113,8 +113,8 @@ describe 'php_config' do
 
   describe 'another path' do
     before do
-      node.set['config-spec']['config_dir'] = 'etc/php/5.6/conf.d'
-      node.set['config-spec']['ini_suffix'] = ''
+      node.override['config-spec']['config_dir'] = 'etc/php/5.6/conf.d'
+      node.override['config-spec']['ini_suffix'] = ''
     end
 
     it 'creates a .ini file' do
@@ -125,12 +125,12 @@ describe 'php_config' do
   describe 'load priority' do
 
     before do
-      node.set['config-spec']['config_dir'] = 'etc/php/5.6/conf.d'
+      node.override['config-spec']['config_dir'] = 'etc/php/5.6/conf.d'
     end
 
     describe 'with load_priority set to string "5"' do
       before do
-        node.set['config-spec']['load_priority'] = '5'
+        node.override['config-spec']['load_priority'] = '5'
       end
       it 'raises chef validation failed exception' do
         expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
@@ -139,7 +139,7 @@ describe 'php_config' do
 
     describe 'with load_priority set to 500' do
       before do
-        node.set['config-spec']['load_priority'] = 500
+        node.override['config-spec']['load_priority'] = 500
       end
       it 'raises RuntimeError exception' do
         expect { chef_run }.to raise_error(RuntimeError)
@@ -148,7 +148,7 @@ describe 'php_config' do
 
     describe 'with load_priority set to 50' do
       before do
-        node.set['config-spec']['load_priority'] = 50
+        node.override['config-spec']['load_priority'] = 50
       end
       it 'creates a .ini file with prefix of 50-' do
         expect(chef_run).to render_file('/prefix/dir/etc/php/5.6/conf.d/50-modulename-settings.ini')
@@ -157,7 +157,7 @@ describe 'php_config' do
 
     describe 'with load_priority set to 5' do
       before do
-        node.set['config-spec']['load_priority'] = 5
+        node.override['config-spec']['load_priority'] = 5
       end
       it 'creates a .ini file with prefix of 05-' do
         expect(chef_run).to render_file('/prefix/dir/etc/php/5.6/conf.d/05-modulename-settings.ini')

--- a/php/spec/provider-ppapackage_spec.rb
+++ b/php/spec/provider-ppapackage_spec.rb
@@ -41,7 +41,7 @@ describe 'php_ppa_package' do
 
   describe 'with config, no separate name' do
     before do
-      node.set['ppa_package-spec']['config'] = { 'key' => 'value' }
+      node.override['ppa_package-spec']['config'] = { 'key' => 'value' }
     end
 
     it 'installs the module' do
@@ -65,8 +65,8 @@ describe 'php_ppa_package' do
 
   describe 'with config, with separate name' do
     before do
-      node.set['ppa_package-spec']['config'] = { 'key' => 'value' }
-      node.set['ppa_package-spec']['packagename'] = 'packagename'
+      node.override['ppa_package-spec']['config'] = { 'key' => 'value' }
+      node.override['ppa_package-spec']['packagename'] = 'packagename'
     end
 
     it 'installs the module' do

--- a/phpmyadmin/metadata.rb
+++ b/phpmyadmin/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'phpmyadmin'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/postfix/metadata.rb
+++ b/postfix/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Setup Postfix as a relay'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/prosody/metadata.rb
+++ b/prosody/metadata.rb
@@ -2,6 +2,8 @@ name              'prosody'
 maintainer        'Till Klampaeckel, Florian Holzhauer'
 maintainer_email  'till@php.net'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 supports 'freebsd'

--- a/qafoo-profiler/metadata.rb
+++ b/qafoo-profiler/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Installs the agent to collect xhprof data for the qafoo-profiler'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/rds/metadata.rb
+++ b/rds/metadata.rb
@@ -5,5 +5,7 @@ license           'New BSD License'
 description       'Performs backups from Amazon RDS to Amazon S3'
 version           '0.0.4'
 recipe            'rds::backup', 'Installs the backup system'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/redis/metadata.rb
+++ b/redis/metadata.rb
@@ -6,6 +6,8 @@ description       'Installs and configures redis server.'
 version           '0.1'
 recipe            'redis::default', 'Installs redis'
 recipe            'redis::monit', 'Installs related to monitor redis through monit'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/rsyslogd/metadata.rb
+++ b/rsyslogd/metadata.rb
@@ -4,5 +4,7 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Rsyslog specific improvements'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'

--- a/ruby-brightbox/metadata.rb
+++ b/ruby-brightbox/metadata.rb
@@ -5,6 +5,8 @@ license          'New BSD license'
 description      'Installs ruby'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/satis/metadata.rb
+++ b/satis/metadata.rb
@@ -5,6 +5,8 @@ license           'BSD License'
 description       'Tools for the satis repo'
 version           '0.1'
 recipe            'satis::s3-syncer', 'Deploys s3-syncer for composer-s3-bindings'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/sinopia-github/metadata.rb
+++ b/sinopia-github/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email 'joel.gilley@imagineeasy.com'
 license 'BSD License'
 description 'Installs sinopia-github'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 version '0.0.1'
 supports 'ubuntu', '>= 12.04'
 supports 'redhat'

--- a/sinopia/metadata.rb
+++ b/sinopia/metadata.rb
@@ -6,6 +6,8 @@ description 'Install a sinopia NPM server (cache & private repo)
 See : https://github.com/rlidwka/sinopia/'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.3.0'
+source_url        'https://github.com/BarthV/sinopia-cookbook' if respond_to?(:source_url)
+issues_url        'https://github.com/BarthV/sinopia-cookbook/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu', '>= 12.04'
 supports 'redhat'

--- a/smokeping/metadata.rb
+++ b/smokeping/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Installs smokeping'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 depends 'easybib'
 depends 'nginx-app'

--- a/smokeping/spec/smokeping_configure_spec.rb
+++ b/smokeping/spec/smokeping_configure_spec.rb
@@ -48,8 +48,8 @@ describe 'smokeping_configure' do
 
   describe 'smokeping installation with probes set in config' do
     before do
-      node.set['smokeping']['probes']['TCPPing'] = { 'binary' => '/whatever' }
-      node.set['smokeping']['probes']['HPing']   = { 'binary' => '/whatever_else' }
+      node.override['smokeping']['probes']['TCPPing'] = { 'binary' => '/whatever' }
+      node.override['smokeping']['probes']['HPing']   = { 'binary' => '/whatever_else' }
     end
     it 'does include hping and tcpping recipes' do
       expect(chef_run).to include_recipe('smokeping::tcpping')
@@ -59,7 +59,7 @@ describe 'smokeping_configure' do
 
   describe 'smokeping installation with targets set in config' do
     before do
-      node.set['smokeping']['targets']['foogroup'] = [
+      node.override['smokeping']['targets']['foogroup'] = [
         {
           'host' => 'foo.com',
           'menu' => 'foo',

--- a/stack-academy/metadata.rb
+++ b/stack-academy/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Academy Stack'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-academy/spec/deploy_spec.rb
+++ b/stack-academy/spec/deploy_spec.rb
@@ -21,18 +21,18 @@ describe 'stack-academy::deploy' do
 
       stub_command('rm -f /etc/nginx/sites-enabled/default').and_return(true)
 
-      node.set['easybib']['cluster_name'] = stack
+      node.override['easybib']['cluster_name'] = stack
 
-      node.set['opsworks']['instance']['layers'] = ['nginxphpapp']
-      node.set['opsworks']['stack']['name'] = stack
+      node.override['opsworks']['instance']['layers'] = ['nginxphpapp']
+      node.override['opsworks']['stack']['name'] = stack
 
-      node.set['deploy']['infolit'] = {
+      node.override['deploy']['infolit'] = {
         'deploy_to' => '/srv/www/infolit',
         'document_root' => 'www',
         'domains' => ['foo.tld']
       }
 
-      node.set['infolit']['domain'] = 'infolit.tld'
+      node.override['infolit']['domain'] = 'infolit.tld'
     end
 
     it 'creates the virtualhost from the correct erb' do

--- a/stack-api/metadata.rb
+++ b/stack-api/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'API roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-api/spec/role-nginxphpapp_spec.rb
+++ b/stack-api/spec/role-nginxphpapp_spec.rb
@@ -6,11 +6,11 @@ describe 'stack-api::role-nginxphpapp' do
   let(:node)         { runner.node }
 
   before do
-    node.set['opsworks']['stack']['name'] = 'Stack'
-    node.set['opsworks']['instance']['layers'] = ['silex']
-    node.set['opsworks']['instance']['hostname'] = 'host'
-    node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-    node.set['deploy']['sitescraper'] = {
+    node.override['opsworks']['stack']['name'] = 'Stack'
+    node.override['opsworks']['instance']['layers'] = ['silex']
+    node.override['opsworks']['instance']['hostname'] = 'host'
+    node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+    node.override['deploy']['sitescraper'] = {
       :deploy_to => '/srv/www/silex',
       :document_root => 'public'
     }

--- a/stack-citationapi/metadata.rb
+++ b/stack-citationapi/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'CitationAPI roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-citationapi/spec/deploy-citationapi_spec.rb
+++ b/stack-citationapi/spec/deploy-citationapi_spec.rb
@@ -16,11 +16,11 @@ describe 'stack-citationapi::deploy-citationapi' do
     let(:app_config_shortname) { 'citation_apis' }
 
     before do
-      node.set['deploy']['citation_apis'] = {
+      node.override['deploy']['citation_apis'] = {
         'deploy_to' => '/srv/www/citation_apis',
         'document_root' => 'public'
       }
-      node.set['opsworks']['instance']['layers'] = ['citation-apis']
+      node.override['opsworks']['instance']['layers'] = ['citation-apis']
     end
 
     it_behaves_like 'silex nginx template'
@@ -30,11 +30,11 @@ describe 'stack-citationapi::deploy-citationapi' do
     let(:app_config_shortname) { 'easybib_api' }
 
     before do
-      node.set['deploy']['easybib_api'] = {
+      node.override['deploy']['easybib_api'] = {
         'deploy_to' => '/srv/www/easybib_api',
         'document_root' => 'public'
       }
-      node.set['opsworks']['instance']['layers'] = ['bibapi']
+      node.override['opsworks']['instance']['layers'] = ['bibapi']
     end
 
     it_behaves_like 'silex nginx template'
@@ -44,11 +44,11 @@ describe 'stack-citationapi::deploy-citationapi' do
     let(:app_config_shortname) { 'sitescraper' }
 
     before do
-      node.set['deploy']['sitescraper'] = {
+      node.override['deploy']['sitescraper'] = {
         'deploy_to' => '/srv/www/sitescraper',
         'document_root' => 'public'
       }
-      node.set['opsworks']['instance']['layers'] = ['sitescraper']
+      node.override['opsworks']['instance']['layers'] = ['sitescraper']
     end
 
     it_behaves_like 'silex nginx template'
@@ -59,12 +59,12 @@ describe 'stack-citationapi::deploy-citationapi' do
     let(:deploy_to) { '/srv/www/pdf_autocite' }
 
     before do
-      node.set['deploy']['pdf_autocite'] = {
+      node.override['deploy']['pdf_autocite'] = {
         'deploy_to' => deploy_to,
         'document_root' => 'web',
         'domains' => ['pdf.example.org']
       }
-      node.set['opsworks']['instance']['layers'] = ['pdf_autocite']
+      node.override['opsworks']['instance']['layers'] = ['pdf_autocite']
     end
 
     it 'calls all necessary LWRP' do

--- a/stack-citationapi/spec/role-citation-data-api_spec.rb
+++ b/stack-citationapi/spec/role-citation-data-api_spec.rb
@@ -8,11 +8,11 @@ describe 'stack-citationapi::role-citation-data-api' do
 
   describe 'OpsWorks' do
     before do
-      node.set['opsworks']['stack']['name'] = 'Stack'
-      node.set['opsworks']['instance']['layers'] = ['citation-apis']
-      node.set['opsworks']['instance']['hostname'] = 'host'
-      node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-      node.set['deploy']['citation_apis'] = {
+      node.override['opsworks']['stack']['name'] = 'Stack'
+      node.override['opsworks']['instance']['layers'] = ['citation-apis']
+      node.override['opsworks']['instance']['hostname'] = 'host'
+      node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+      node.override['deploy']['citation_apis'] = {
         'deploy_to' => '/srv/www/citation_apis',
         'document_root' => 'public'
       }
@@ -36,7 +36,7 @@ describe 'stack-citationapi::role-citation-data-api' do
 
   describe 'vagrant' do
     before do
-      node.set['vagrant']['applications'] = {}
+      node.override['vagrant']['applications'] = {}
     end
 
     it 'uses deploy-vagrant' do

--- a/stack-citationapi/spec/role-citation-formatting-api_spec.rb
+++ b/stack-citationapi/spec/role-citation-formatting-api_spec.rb
@@ -6,11 +6,11 @@ describe 'stack-citationapi::role-formatting-api' do
   let(:chef_run) { runner.converge(described_recipe) }
   let(:node)     { runner.node }
   before do
-    node.set['opsworks']['stack']['name'] = 'Stack'
-    node.set['opsworks']['instance']['layers'] = ['bibapi']
-    node.set['opsworks']['instance']['hostname'] = 'host'
-    node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-    node.set['deploy']['easybib_api'] = {
+    node.override['opsworks']['stack']['name'] = 'Stack'
+    node.override['opsworks']['instance']['layers'] = ['bibapi']
+    node.override['opsworks']['instance']['hostname'] = 'host'
+    node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+    node.override['deploy']['easybib_api'] = {
       'deploy_to' => '/srv/www/bibapi',
       'document_root' => 'public'
     }

--- a/stack-citationapi/spec/role-citation-pdf-api_spec.rb
+++ b/stack-citationapi/spec/role-citation-pdf-api_spec.rb
@@ -7,11 +7,11 @@ describe 'stack-citationapi::role-citation-pdf-api' do
 
   describe 'OpsWorks' do
     before do
-      node.set['opsworks']['stack']['name'] = 'Stack'
-      node.set['opsworks']['instance']['layers'] = ['pdf_autocite']
-      node.set['opsworks']['instance']['hostname'] = 'host'
-      node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-      node.set['deploy']['pdf_autocite'] = {
+      node.override['opsworks']['stack']['name'] = 'Stack'
+      node.override['opsworks']['instance']['layers'] = ['pdf_autocite']
+      node.override['opsworks']['instance']['hostname'] = 'host'
+      node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+      node.override['deploy']['pdf_autocite'] = {
         'deploy_to' => '/srv/www/pdf_autocite',
         'document_root' => 'public',
         'domains' => ['domain']
@@ -28,7 +28,7 @@ describe 'stack-citationapi::role-citation-pdf-api' do
 
   describe 'Vagrant' do
     before do
-      node.set['vagrant']['applications'] = {}
+      node.override['vagrant']['applications'] = {}
     end
 
     it 'pulls in all required recipes' do

--- a/stack-citationapi/spec/role-citation-publicapi_spec.rb
+++ b/stack-citationapi/spec/role-citation-publicapi_spec.rb
@@ -7,11 +7,11 @@ describe 'stack-citationapi::role-publicapi' do
   let(:node)     { runner.node }
 
   before do
-    node.set['opsworks']['stack']['name'] = 'Stack'
-    node.set['opsworks']['instance']['layers'] = ['bibapi']
-    node.set['opsworks']['instance']['hostname'] = 'host'
-    node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-    node.set['deploy']['easybib_api'] = {
+    node.override['opsworks']['stack']['name'] = 'Stack'
+    node.override['opsworks']['instance']['layers'] = ['bibapi']
+    node.override['opsworks']['instance']['hostname'] = 'host'
+    node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+    node.override['deploy']['easybib_api'] = {
       :deploy_to => '/srv/www/bibapi',
       :document_root => 'public'
     }

--- a/stack-citationapi/spec/role-lb_spec.rb
+++ b/stack-citationapi/spec/role-lb_spec.rb
@@ -7,11 +7,11 @@ describe 'stack-citationapi::role-lb' do
   let(:node)        { runner.node }
 
   before do
-    node.set['opsworks']['stack']['name'] = 'Stack'
-    node.set['opsworks']['instance']['layers'] = ['bibapi']
-    node.set['opsworks']['instance']['hostname'] = 'host'
-    node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-    node.set['deploy']['easybib_api'] = {
+    node.override['opsworks']['stack']['name'] = 'Stack'
+    node.override['opsworks']['instance']['layers'] = ['bibapi']
+    node.override['opsworks']['instance']['hostname'] = 'host'
+    node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+    node.override['deploy']['easybib_api'] = {
       :deploy_to => '/srv/www/bibapi',
       :document_root => 'public'
     }

--- a/stack-citationapi/spec/role-phpapp_spec.rb
+++ b/stack-citationapi/spec/role-phpapp_spec.rb
@@ -24,7 +24,7 @@ describe 'stack-citationapi::role-phpapp' do
   end
   it 'sets up composer' do
     # todo
-    # node.set['composer']['environment'] = get_deploy_user if is_aws
+    # node.override['composer']['environment'] = get_deploy_user if is_aws
     expect(chef_run).to include_recipe('composer::configure')
   end
 end

--- a/stack-citationapi/spec/role-sitescraper_spec.rb
+++ b/stack-citationapi/spec/role-sitescraper_spec.rb
@@ -8,11 +8,11 @@ describe 'stack-citationapi::role-sitescraper' do
 
   describe 'OpsWorks' do
     before do
-      node.set['opsworks']['stack']['name'] = 'Stack'
-      node.set['opsworks']['instance']['layers'] = ['sitescraper']
-      node.set['opsworks']['instance']['hostname'] = 'host'
-      node.set['opsworks']['instance']['ip'] = '127.0.0.1'
-      node.set['deploy']['sitescraper'] = {
+      node.override['opsworks']['stack']['name'] = 'Stack'
+      node.override['opsworks']['instance']['layers'] = ['sitescraper']
+      node.override['opsworks']['instance']['hostname'] = 'host'
+      node.override['opsworks']['instance']['ip'] = '127.0.0.1'
+      node.override['deploy']['sitescraper'] = {
         'deploy_to' => '/srv/www/sitescraper',
         'document_root' => 'public'
       }
@@ -36,7 +36,7 @@ describe 'stack-citationapi::role-sitescraper' do
 
   describe 'vagrant' do
     before do
-      node.set['vagrant']['applications'] = {
+      node.override['vagrant']['applications'] = {
         :sitescraper => {
           :default_router => 'index_tralala.php',
           :deploy_dir => '/vagrant_autocite',

--- a/stack-cmbm/metadata.rb
+++ b/stack-cmbm/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'brian.wiborg@imagineeasy.com'
 license           'BSD 2-clause'
 description       'CitationMachine and BibMe Roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-cmbm/spec/deploy-nginxapp_spec.rb
+++ b/stack-cmbm/spec/deploy-nginxapp_spec.rb
@@ -15,8 +15,8 @@ describe 'stack-cmbm::deploy-nginxapp' do
   let(:template_name) { "/etc/nginx/sites-enabled/#{app_config_shortname}.conf" }
 
   before do
-    node.set['opsworks']['instance']['layers'] = ['nginxapp_cm']
-    node.set[:deploy][:cm] = {
+    node.override['opsworks']['instance']['layers'] = ['nginxapp_cm']
+    node.override[:deploy][:cm] = {
       :application => 'cm',
       :deploy_to => '/srv/cm',
       :deploy_dir => '/srv/cm',
@@ -27,7 +27,7 @@ describe 'stack-cmbm::deploy-nginxapp' do
         }
       }
     }
-    node.set[:etc][:passwd]['www-data'][:dir] = '/srv/www/cm'   # because OHAI is not around
+    node.override[:etc][:passwd]['www-data'][:dir] = '/srv/www/cm'   # because OHAI is not around
   end
 
   it 'includes all required recipes' do

--- a/stack-cmbm/spec/role-nginxapp_spec.rb
+++ b/stack-cmbm/spec/role-nginxapp_spec.rb
@@ -7,7 +7,7 @@ describe 'stack-cmbm::role-nginxapp' do
   let(:node)      { runner.node }
 
   before do
-    node.set[:vagrant][:applications] = {
+    node.override[:vagrant][:applications] = {
       :cmbm => {
         :app_root_location => '/vagrant_cmbm',
         :doc_root_location => '/vagrant_cmbm/public'

--- a/stack-cmbm/spec/role-vagrant_spec.rb
+++ b/stack-cmbm/spec/role-vagrant_spec.rb
@@ -7,7 +7,7 @@ describe 'stack-cmbm::role-vagrant' do
   let(:node)      { runner.node }
 
   before do
-    node.set[:vagrant][:applications] = {
+    node.override[:vagrant][:applications] = {
       :cmbm => {
         :app_root_location => '/vagrant_cmbm',
         :doc_root_location => '/vagrant_cmbm/public'

--- a/stack-easybib/metadata.rb
+++ b/stack-easybib/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'API roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-easybib/spec/role-nginxapp_spec.rb
+++ b/stack-easybib/spec/role-nginxapp_spec.rb
@@ -19,10 +19,10 @@ describe 'stack-easybib::role-nginxphpapp' do
   describe 'deployment' do
     before do
       stub_command('rm -f /etc/nginx/sites-enabled/default').and_return(true)
-      node.set['deploy'] = {}
-      node.set['easybib']['cluster_name'] = stack
-      node.set['opsworks']['stack']['name'] = stack
-      node.set['opsworks']['instance'] = {
+      node.override['deploy'] = {}
+      node.override['easybib']['cluster_name'] = stack
+      node.override['opsworks']['stack']['name'] = stack
+      node.override['opsworks']['instance'] = {
         'layers' => ['nginxphpapp'],
         'hostname' => 'hostname',
         'ip' => '127.0.0.1'
@@ -31,11 +31,11 @@ describe 'stack-easybib::role-nginxphpapp' do
 
     describe 'virtualhost' do
       before do
-        node.set['deploy']['easybib'] = {
+        node.override['deploy']['easybib'] = {
           'deploy_to' => '/srv/www/easybib',
           'document_root' => 'public'
         }
-        node.set['nginx-app']['access_log'] = access_log
+        node.override['nginx-app']['access_log'] = access_log
       end
 
       it "writes virtualhost for app 'easybib'" do
@@ -91,7 +91,7 @@ describe 'stack-easybib::role-nginxphpapp' do
 
       describe 'pools' do
         before do
-          node.set['php-fpm']['pools'] = %w(www1 www2 www3)
+          node.override['php-fpm']['pools'] = %w(www1 www2 www3)
         end
 
         it 'creates three upstreams' do

--- a/stack-easybib/spec/role-vagrant_spec.rb
+++ b/stack-easybib/spec/role-vagrant_spec.rb
@@ -7,7 +7,7 @@ describe 'stack-easybib::role-vagrant' do
   let(:node)     { runner.node }
 
   before do
-    node.set['vagrant']['applications']['www'] = {}
+    node.override['vagrant']['applications']['www'] = {}
   end
 
   it 'should set up a basic vagrantbox with php and mysql' do

--- a/stack-fruitkid/metadata.rb
+++ b/stack-fruitkid/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'CitationAPI roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-ops/metadata.rb
+++ b/stack-ops/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'ops infrastructure roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-qa/metadata.rb
+++ b/stack-qa/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'ops infrastructure roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-research/metadata.rb
+++ b/stack-research/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'research roles'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-scholar/metadata.rb
+++ b/stack-scholar/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Scholar Stack'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/stack-scholar/spec/bugs_spec.rb
+++ b/stack-scholar/spec/bugs_spec.rb
@@ -22,14 +22,14 @@ describe 'fixtures::brokenapps' do
   let(:fixtures) { "#{File.dirname(__FILE__)}/fixtures" }
 
   before do
-    node.set['opsworks']['stack']['name'] = 'stack-chefspec'
-    node.set['opsworks']['instance']['layers'] = ['node-chefspec']
+    node.override['opsworks']['stack']['name'] = 'stack-chefspec'
+    node.override['opsworks']['instance']['layers'] = ['node-chefspec']
   end
 
   describe 'broken apps' do
     before do
-      node.set['deploy'] = JSON.parse(File.read("#{fixtures}/deploy.json"))
-      node.set['stack-chefspec']['applications'] = JSON.parse(File.read("#{fixtures}/brokenapps.json"))
+      node.override['deploy'] = JSON.parse(File.read("#{fixtures}/deploy.json"))
+      node.override['stack-chefspec']['applications'] = JSON.parse(File.read("#{fixtures}/brokenapps.json"))
     end
 
     it 'chef throws an exception' do

--- a/stack-scholar/spec/deploy_spec.rb
+++ b/stack-scholar/spec/deploy_spec.rb
@@ -12,13 +12,13 @@ describe 'stack-scholar::deploy' do
   let(:deploy_data) { { 'deploy_to' => '/bla/dir', 'document_root' => 'www', 'domains' => ['foo.tld'] } }
 
   before do
-    node.set['opsworks']['stack']['name'] = 'chefspec'
+    node.override['opsworks']['stack']['name'] = 'chefspec'
   end
 
   describe 'scholar_admin deployment in correct layer' do
     before do
-      node.set['opsworks']['instance']['layers'] = ['nginxphpapp']
-      node.set['deploy']['scholar_admin'] = deploy_data
+      node.override['opsworks']['instance']['layers'] = ['nginxphpapp']
+      node.override['deploy']['scholar_admin'] = deploy_data
     end
 
     it 'includes the service definition recipes' do
@@ -46,8 +46,8 @@ describe 'stack-scholar::deploy' do
 
   describe 'scholar_admin deployment in wrong layer' do
     before do
-      node.set['opsworks']['instance']['layers'] = ['wronglayer']
-      node.set['deploy']['scholar_admin'] = deploy_data
+      node.override['opsworks']['instance']['layers'] = ['wronglayer']
+      node.override['deploy']['scholar_admin'] = deploy_data
     end
 
     it 'does not deploy the application' do
@@ -62,8 +62,8 @@ describe 'stack-scholar::deploy' do
   # scholar main app
   describe 'scholar deployment in nginxlayer' do
     before do
-      node.set['opsworks']['instance']['layers'] = ['nginxphpapp']
-      node.set['deploy']['scholar'] = deploy_data
+      node.override['opsworks']['instance']['layers'] = ['nginxphpapp']
+      node.override['deploy']['scholar'] = deploy_data
     end
 
     it 'includes the service definition recipes' do
@@ -91,9 +91,9 @@ describe 'stack-scholar::deploy' do
 
   describe 'scholar deployment in supervisor layer' do
     before do
-      node.set['opsworks']['instance']['layers'] = ['supervisor_role']
-      node.set['easybib_deploy']['supervisor_role'] = 'supervisor_role'
-      node.set['deploy']['scholar'] = deploy_data
+      node.override['opsworks']['instance']['layers'] = ['supervisor_role']
+      node.override['easybib_deploy']['supervisor_role'] = 'supervisor_role'
+      node.override['deploy']['scholar'] = deploy_data
     end
 
     # not testing for values or nginx here, since this is redundant to test above
@@ -104,8 +104,8 @@ describe 'stack-scholar::deploy' do
 
   describe 'scholar deployment in wrong layer' do
     before do
-      node.set['opsworks']['instance']['layers'] = ['wronglayer']
-      node.set['deploy']['scholar'] = deploy_data
+      node.override['opsworks']['instance']['layers'] = ['wronglayer']
+      node.override['deploy']['scholar'] = deploy_data
     end
 
     it 'does not deploy the application' do

--- a/stack-scholar/spec/nginx_spec.rb
+++ b/stack-scholar/spec/nginx_spec.rb
@@ -21,18 +21,18 @@ describe 'stack-scholar::deploy' do
 
       stub_command('rm -f /etc/nginx/sites-enabled/default').and_return(true)
 
-      node.set['easybib']['cluster_name'] = stack
+      node.override['easybib']['cluster_name'] = stack
 
-      node.set['opsworks']['instance']['layers'] = ['nginxphpapp']
-      node.set['opsworks']['stack']['name'] = stack
+      node.override['opsworks']['instance']['layers'] = ['nginxphpapp']
+      node.override['opsworks']['stack']['name'] = stack
 
-      node.set['deploy']['scholar'] = {
+      node.override['deploy']['scholar'] = {
         'deploy_to' => '/srv/www/scholar',
         'document_root' => 'docroot',
         'domains' => [domain]
       }
 
-      node.set['infolit']['domain'] = domain
+      node.override['infolit']['domain'] = domain
     end
 
     it 'creates the virtualhost from the correct erb' do

--- a/stack-service/metadata.rb
+++ b/stack-service/metadata.rb
@@ -3,7 +3,9 @@ maintainer 'Till Klampaeckel'
 maintainer_email 'till@php.net'
 license 'BSD-2-Clause'
 description 'Role recipes for the service stack'
-
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
+version           '0.1'
 depends 'gearmand'
 depends 'logrotate'
 depends 'rabbitmq'

--- a/stack-service/spec/role-rabbitmq_spec.rb
+++ b/stack-service/spec/role-rabbitmq_spec.rb
@@ -12,12 +12,12 @@ describe 'stack-service::role-rabbitmq' do
   let(:chef_run)  { runner.converge(described_recipe) }
 
   before do
-    node.set['rabbitmq']['erlang_cookie_path'] = File.dirname(__FILE__) << '/erlang_cookie'
+    node.override['rabbitmq']['erlang_cookie_path'] = File.dirname(__FILE__) << '/erlang_cookie'
   end
 
   describe 'stack-service::role-rabbitmq' do
     before do
-      node.set['logrotate']['global']['/mnt/logs/rabbitmq/*.log'] = {
+      node.override['logrotate']['global']['/mnt/logs/rabbitmq/*.log'] = {
         :missingok  => true,
         :monthly    => true,
         :create     => '0660 root adm',

--- a/stack-service/spec/role-statsd_spec.rb
+++ b/stack-service/spec/role-statsd_spec.rb
@@ -20,7 +20,7 @@ describe 'stack-service::role-statsd' do
 
   describe 'stack-service::role-statsd' do
     before do
-      node.set['easybib'] = {
+      node.override['easybib'] = {
         'cluster_name' => 'vagrant-test'
       }
     end

--- a/stack-test/metadata.rb
+++ b/stack-test/metadata.rb
@@ -1,4 +1,9 @@
 name 'stack-test'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
+version           '0.1'
+maintainer 'Till Klampaeckel'
+maintainer_email 'till@php.net'
 
 depends 'supervisor'
 depends 'ies'

--- a/stack-wpt/metadata.rb
+++ b/stack-wpt/metadata.rb
@@ -1,7 +1,10 @@
 name 'stack-wpt'
-
+maintainer 'Till Klampaeckel'
+maintainer_email 'till@php.net'
 license 'Apache-2.0'
-
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
+version           '0.1'
 depends 'ark'
 depends 'fake-sqs'
 depends 'fake-s3'

--- a/stack-wpt/spec/vagrant_spec.rb
+++ b/stack-wpt/spec/vagrant_spec.rb
@@ -14,7 +14,7 @@ describe 'stack-wpt::role-vagrant' do
   let(:php_version) { '7.0' }
 
   before do
-    node.set['vagrant']['applications'] = {}
+    node.override['vagrant']['applications'] = {}
   end
 
   describe 'nodejs/npm setup' do

--- a/statsd/metadata.rb
+++ b/statsd/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Setup StatsD with Librato-Backend'
 version           '0.2.0'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/tideways/metadata.rb
+++ b/tideways/metadata.rb
@@ -3,7 +3,9 @@ maintainer 'Till Klampaeckel'
 maintainer_email 'till@php.net'
 license 'BSD-2-Clause'
 description 'Install and configure tideways daemon and PHP extension'
-
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
+version           '0.1'
 depends 'apt'
 depends 'php'
 depends 'php-fpm'

--- a/tsung/metadata.rb
+++ b/tsung/metadata.rb
@@ -4,6 +4,8 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Setup tsung and nginx to view its stats.'
 version           '0.2'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'
 

--- a/users/metadata.rb
+++ b/users/metadata.rb
@@ -4,5 +4,7 @@ maintainer_email  'till@php.net'
 license           'BSD License'
 description       'Installl user accounts.'
 version           '0.1'
+source_url        'https://github.com/till/easybib-cookbooks' if respond_to?(:source_url)
+issues_url        'https://github.com/till/easybib-cookbooks/issues' if respond_to?(:issues_url)
 
 supports 'ubuntu'


### PR DESCRIPTION
Related: https://github.com/easybib/ops/issues/225

Backports the backward compatible preparations for Chef12, new foodcritic and chefspec. This way, the diff and maintenance overhead while having to maintain both variants will be somewhat smaller. **Note: This is only a preparation in the tests and metadata, there is no update or change in Gemfile**

Actual changes in cookbooks:
 * `php::module-poppler-pdf`: Passing `{}` as value is not supported here
 * `php::module-aws_elasticache_cluster_client`: Passing `{}` as value is not supported here

Most of the changes affect only tests and metadata: 
 * Introduces `source_url` and `issues_url` in `metadata.rb`
 * Adds missing versions and maintainer metadata where applicable
 * moves deprecated `node.set` to `node.override` in tests
 * Style-changes in `Rakefile` 