### PR TITLE
Fix: provider used does not work on 14.04

### DIFF
--- a/php-fpm/recipes/service.rb
+++ b/php-fpm/recipes/service.rb
@@ -1,18 +1,18 @@
-if node['php']['ppa']['package_prefix'].include?('easybib')
-  service_name = 'php-fpm'
-  service_provider = Chef::Provider::Service::Init
-else
-  service_name = "#{node['php']['ppa']['package_prefix']}-fpm"
-  service_provider = if node['platform_version'] == '16.04'
-                       Chef::Provider::Service::Systemd
-                     else
-                       Chef::Provider::Service::Upstart
-                     end
-end
+service_name = if node['php']['ppa']['package_prefix'].include?('easybib')
+                 'php-fpm'
+               else
+                 "#{node['php']['ppa']['package_prefix']}-fpm"
+               end
 
 service 'php-fpm' do
   action :nothing
-  provider service_provider
+  unless node['php']['ppa']['package_prefix'].include?('easybib')
+    if node['platform_version'] == '16.04'
+      provider Chef::Provider::Service::Systemd
+    else
+      provider Chef::Provider::Service::Upstart
+    end
+  end
   service_name service_name
   supports [:start, :stop, :status, :reload, :restart]
 end


### PR DESCRIPTION
# Changes

Provider on 14.04 is not `Init`, we fall back to the Chef default (which worked before).
