### PR TITLE
Enhancement: support for MS SQL Server

### DIFF
--- a/php/attributes/default.rb
+++ b/php/attributes/default.rb
@@ -73,3 +73,11 @@ default['poppler']['package_distro'] = 'trusty'
 default['poppler']['package_components'] = ['main']
 default['poppler']['package_key_uri'] = 'packagecloud-poppler.gpg'
 default['poppler']['package_list'] = ['poppler', 'poppler-glib', 'php-poppler-pdf']
+
+default['freetds'] = {
+  'server_name' => nil,
+  'host' => nil,
+  'port' => 1433,
+  'tds_version' => 8.0,
+  'charset' => 'UTF-8'
+}

--- a/php/recipes/module-sybase.rb
+++ b/php/recipes/module-sybase.rb
@@ -6,7 +6,7 @@ package 'freetds-bin' do
   end
 end
 
-package 'php5-sybase' do
+package "#{node['php']['ppa']['package_prefix']}-sybase" do
   not_if do
     node['php']['ppa']['package_prefix'] == 'php5-easybib' || config['server_name'].nil?
   end

--- a/php/recipes/module-sybase.rb
+++ b/php/recipes/module-sybase.rb
@@ -1,0 +1,23 @@
+config = node['freetds']
+
+package 'freetds-bin' do
+  not_if do
+    config['server_name'].nil?
+  end
+end
+
+package 'php5-sybase' do
+  not_if do
+    node['php']['ppa']['package_prefix'] == 'php5-easybib' || config['server_name'].nil?
+  end
+end
+
+template '/etc/freetds/freetds.conf' do
+  source 'freetds.erb'
+  variables(
+    :config => config
+  )
+  not_if do
+    config['server_name'].nil?
+  end
+end

--- a/php/spec/module-sybase_spec.rb
+++ b/php/spec/module-sybase_spec.rb
@@ -24,7 +24,6 @@ describe 'php::module-sybase' do
       node.override['freetds'] = {
         'server_name' => 'my_mssql_server',
         'host' => 'some.host.lan'
-
       }
 
       node.override['php']['ppa'] = {
@@ -33,9 +32,9 @@ describe 'php::module-sybase' do
         'package_prefix' => 'php7.0'
       }
     end
-    it 'installs freetds and php5-sybase' do
+    it 'installs freetds and phpXXX-sybase' do
       expect(chef_run).to install_package('freetds-bin')
-      expect(chef_run).to install_package('php5-sybase')
+      expect(chef_run).to install_package('php7.0-sybase')
     end
 
     it 'configures freetds' do

--- a/php/spec/module-sybase_spec.rb
+++ b/php/spec/module-sybase_spec.rb
@@ -1,0 +1,56 @@
+require_relative 'spec_helper.rb'
+
+describe 'php::module-sybase' do
+
+  let(:runner)    { ChefSpec::Runner.new }
+  let(:chef_run)  { runner.converge(described_recipe) }
+  let(:node)      { runner.node }
+
+  let(:freetds_config) { '/etc/freetds/freetds.conf' }
+
+  describe 'php5-easybib' do
+    it 'does not install freetds and php5-easybib' do
+      expect(chef_run).not_to install_package('freetds-bin')
+      expect(chef_run).not_to install_package('php5-sybase')
+    end
+
+    it 'does not render the freetds config' do
+      expect(chef_run).not_to render_file(freetds_config)
+    end
+  end
+
+  describe 'ondrej ppa' do
+    before do
+      node.override['freetds'] = {
+        'server_name' => 'my_mssql_server',
+        'host' => 'some.host.lan'
+
+      }
+
+      node.override['php']['ppa'] = {
+        'name' => 'ondrejphp',
+        'uri' => 'ppa:ondrej/php',
+        'package_prefix' => 'php7.0'
+      }
+    end
+    it 'installs freetds and php5-sybase' do
+      expect(chef_run).to install_package('freetds-bin')
+      expect(chef_run).to install_package('php5-sybase')
+    end
+
+    it 'configures freetds' do
+      expect(chef_run).to create_template(freetds_config)
+    end
+
+    it 'creates the config with the correct content' do
+      config_file = "[my_mssql_server]\n"
+      config_file << "  host = some.host.lan\n"
+      config_file << "  port = 1433\n"
+      config_file << "  tds version = 8.0\n"
+      config_file << '  client charset = UTF-8'
+
+      expect(chef_run).to render_file(freetds_config)
+        .with_content(config_file)
+    end
+  end
+end

--- a/php/templates/default/freetds.erb
+++ b/php/templates/default/freetds.erb
@@ -1,0 +1,5 @@
+[<%=@config['server_name']%>]
+  host = <%=@config['host']%>
+  port = <%=@config['port']%>
+  tds version = <%=@config['tds_version']%>
+  client charset = <%=@config['charset']%>

--- a/stack-easybib/recipes/role-vagrant.rb
+++ b/stack-easybib/recipes/role-vagrant.rb
@@ -55,6 +55,9 @@ include_recipe 'stack-easybib::role-gearmanw'
 include_recipe 'ies-nodejs::repo'
 include_recipe 'nodejs::npm'
 
+# mssql server
+include_recipe 'php::module-sybase'
+
 # dev dependencies last
 include_recipe 'php::module-pdo_sqlite'
 include_recipe 'php::module-xdebug'


### PR DESCRIPTION
# Changes

Adds support for `php5-sybase` (and freetds) to allow PHP to talk to MS SQL Server. Only works when a stack is on ondrej PPA.

# CR

 - please update the stable PR post-merge

Related: easybib/sbm-issues#841