### PR TITLE
Fix: supply 'local' key to apt_repository

### DIFF
--- a/php/recipes/dependencies-ppa.rb
+++ b/php/recipes/dependencies-ppa.rb
@@ -6,6 +6,8 @@ ppa_config = node['php']['ppa']
 
 apt_repository ppa_config['name'] do
   uri           ppa_config['uri']
+  key           '66E3A9B7.gpg'
+  cookbook      'aptly'
   distribution  node['lsb']['codename']
   components    ['main']
 end

--- a/php/recipes/dependencies-ppa.rb
+++ b/php/recipes/dependencies-ppa.rb
@@ -6,8 +6,10 @@ ppa_config = node['php']['ppa']
 
 apt_repository ppa_config['name'] do
   uri           ppa_config['uri']
-  key           '66E3A9B7.gpg'
-  cookbook      'aptly'
+  if ppa_config['package_prefix'] == 'php5-easybib'
+    key      '66E3A9B7.gpg'
+    cookbook 'aptly'
+  end
   distribution  node['lsb']['codename']
   components    ['main']
 end


### PR DESCRIPTION
# Changes

This is to prevent instances from calling Ubuntu's keyserver
which is notoriously unstable. :shit:

Uses the keys contained within the `aptly` cookbook. Not ideal
but it should work.

# CR

 - pull this PR, `cd autocite && vagrant up`
 - please update the stable PR post-merge

Related: easybib/ops#235