### PR TITLE
Cleanup: Remove envvar_json_source

### DIFF
--- a/easybib/attributes/default.rb
+++ b/easybib/attributes/default.rb
@@ -1,5 +1,4 @@
 default['easybib_deploy']['gearman_file']  = 'pecl_manager_env'
-default['easybib_deploy']['env_source']    = nil
 default['easybib_deploy']['provide_pear']  = false
 default['easybib_deploy']['cron_path']     = '/usr/local/bin:/usr/bin:/bin'
 default['easybib_deploy']['envtype']       = 'playground'

--- a/easybib/providers/deploy.rb
+++ b/easybib/providers/deploy.rb
@@ -48,9 +48,7 @@ action :deploy do
     instance_roles instance_roles
   end
 
-  easybib_gearmanw application_root_dir do
-    envvar_json_source new_resource.envvar_json_source
-  end
+  easybib_gearmanw application_root_dir
 
   cookbook_file "#{document_root_dir}/robots.txt" do
     mode   '0644'

--- a/easybib/providers/gearmanw.rb
+++ b/easybib/providers/gearmanw.rb
@@ -10,7 +10,6 @@ action :create do
     p = pecl_manager_script 'Setting up Pecl Manager' do
       dir                application_root_dir
       envvar_file        import_file
-      envvar_json_source new_resource.envvar_json_source
     end
 
     new_resource.updated_by_last_action(p.updated_by_last_action?)

--- a/easybib/resources/deploy.rb
+++ b/easybib/resources/deploy.rb
@@ -4,7 +4,6 @@ default_action :deploy
 
 attribute :app, :default => {}
 attribute :deploy_data, :default => {}
-attribute :envvar_json_source, :kind_of => String, :default => nil
 attribute :cronjob_role, :kind_of => String, :default => nil
 attribute :supervisor_role, :kind_of => String, :default => nil
 attribute :instance_roles, :default => []

--- a/easybib/resources/gearmanw.rb
+++ b/easybib/resources/gearmanw.rb
@@ -3,4 +3,3 @@ actions :create
 default_action :create
 
 attribute :application_root_dir, :name_attribute => true
-attribute :envvar_json_source, :kind_of => String, :default => nil

--- a/easybib/spec/easybib_gearmanw_spec.rb
+++ b/easybib/spec/easybib_gearmanw_spec.rb
@@ -28,8 +28,7 @@ describe 'easybib_gearmanw' do
         expect(chef_run).to create_pecl_manager_script('Setting up Pecl Manager')
           .with(
             :dir => '/some_dir',
-            :envvar_file => '/some_dir/deploy/pecl_manager_env',
-            :envvar_json_source => 'some-source'
+            :envvar_file => '/some_dir/deploy/pecl_manager_env'
           )
       end
     end

--- a/easybib/spec/fixtures/recipes/easybib_gearmanw.rb
+++ b/easybib/spec/fixtures/recipes/easybib_gearmanw.rb
@@ -1,3 +1,1 @@
-easybib_gearmanw '/some_dir' do
-  envvar_json_source 'some-source'
-end
+easybib_gearmanw '/some_dir'

--- a/pecl-manager/README.md
+++ b/pecl-manager/README.md
@@ -17,7 +17,7 @@ It has been tested in Vagrant (with chef-solo provisioner) and AWS OpsWorks.
 
 ### Platform
 
-- Ubuntu 12.04
+- Ubuntu 14.04
 
 May work with or without modification on other Debian derivatives.
 
@@ -29,10 +29,8 @@ Resources/Providers
 -------------------
 ### `script`
 
-This LWRP provides an easy way to create a `/etc/init.d/pecl-manager` init script. It includes configuration from two different locations, and exports them in the script as environment variables:
+This LWRP provides an easy way to create a `/etc/init.d/pecl-manager` init script. It includes configuration from a file and exports them in the script as environment variables:
 
-- From the node configuration: If you supply the parameter `envvar_json_source`, all key/value-pairs under
-`node[envvar_json_source]` will be exported. See `easybib/libraries/config.rb` for implementation details
 - From a file in the source: The file supplied with the parameter `envvar_file`.
 
 #### Easybib-Deploy
@@ -42,8 +40,8 @@ This LWRP is included in `easybib_deploy` and executed when the `envvar_file` ex
 #### Environment Variables
 
 There are several environment variables used to configure the init script. All of them are provided with a default
-setting - then first the JSON variables, then the variables from `envvar_file` are set. You can therefore
-override all default variables with your custom settings.
+setting, then the variables from `envvar_file` are set. You can therefore override all default variables with your
+custom settings.
 
 Default Variables:
 
@@ -72,7 +70,6 @@ PARAMS="-w /dev/null -vvv"
 
 - `dir` (required): The root directory for the script
 - `envvar_file` (required): The file to include for environment variables (see above)
-- `envvar_json`: The json key to import environment variables from (see above)
 
 #### Examples
 
@@ -80,7 +77,6 @@ PARAMS="-w /dev/null -vvv"
 pecl_manager_script "Setting up Pecl Manager" do
   dir                  "/var/www"
   envvar_file         "/var/www/deploy/pecl_manager_env"
-  envvar_json_source "defaultsettings"
 end
 ```
 

--- a/pecl-manager/providers/script.rb
+++ b/pecl-manager/providers/script.rb
@@ -5,13 +5,6 @@ action :create do
 
   Chef::Log.debug("Pecl-Manager: Importing file #{new_resource.envvar_file} in Startscript")
 
-  envvar_json = ''
-  if new_resource.envvar_json_source.nil?
-    Chef::Log.debug('Pecl-Manager: No source for json env found')
-  else
-    envvar_json = ::EasyBib::Config.get_env('shell', new_resource.envvar_json_source, node)
-  end
-
   # clean up old links to bin/worker
   link '/etc/init.d/pecl-manager' do
     action :delete
@@ -27,7 +20,6 @@ action :create do
     variables(
       :dir => root_dir,
       :envvar_file => new_resource.envvar_file,
-      :envvar_json => envvar_json,
       :gearman_user => node['pecl-manager']['user']
     )
   end

--- a/pecl-manager/recipes/vagrant.rb
+++ b/pecl-manager/recipes/vagrant.rb
@@ -3,7 +3,6 @@ unless is_aws
   pecl_manager_script 'Setting up Pecl Manager Script for vagrant' do
     dir '/vagrant_gearman'
     envvar_file import_file_path
-    envvar_json_source node['easybib_deploy']['env_source']
     only_if { ::File.exist?(import_file_path) }
   end
 end

--- a/pecl-manager/resources/script.rb
+++ b/pecl-manager/resources/script.rb
@@ -4,4 +4,3 @@ default_action :create
 
 attribute :dir, :kind_of => String, :required => true
 attribute :envvar_file, :kind_of => String, :required => true
-attribute :envvar_json_source, :kind_of => String, :default => nil

--- a/pecl-manager/templates/default/init.d.erb
+++ b/pecl-manager/templates/default/init.d.erb
@@ -23,9 +23,6 @@ LOGFILE=/var/log/gearman-manager.log
 GEARMANUSER="<%= @gearman_user %>"
 PARAMS="-w /dev/null -vvv"
 
-####ENVVARS FROM JSON#####
-<%= @envvar_json %>
-
 ####ENVVARS FROM EXTERNAL FILE#####
 <%= render @envvar_file, :local => true %>
 


### PR DESCRIPTION
Removes the `envvar_json_source` for the gearman setup. We used to use this with getcourse, but it nowadays is nowhere in use.

Any new use case should respect the `.deploy_configuration` mechanism anyway.