### PR TITLE
Refactoring: Remove cronjob_role param - nowhere used

### DIFF
--- a/easybib/libraries/deploy.rb
+++ b/easybib/libraries/deploy.rb
@@ -1,15 +1,5 @@
 module EasyBib
   module Deploy
-    def deploy_crontab?(instance_roles, cronjob_role)
-      return true if cronjob_role.nil?
-
-      return true if instance_roles.include?(cronjob_role)
-
-      debug_log('Instance is not in a cronjob role, skippings cronjob installs')
-
-      false
-    end
-
     # Checks if an application is allowed to be deployed - if the currently to be deployed
     # app matches the one we expect, and if the role of the instances is in an appropriate
     # role for the app.

--- a/easybib/providers/crontab.rb
+++ b/easybib/providers/crontab.rb
@@ -31,7 +31,7 @@ action :create do
 
   create_crontab = deploy_crontab?(
     new_resource.instance_roles,
-    new_resource.cronjob_role
+    node['easybib_deploy']['cronjob_role']
   )
   if create_crontab
     cron = ::EasyBib::Cron.new(app, crontab_file)
@@ -88,4 +88,11 @@ action :delete do
 
   new_resource.updated_by_last_action(true)
 
+end
+
+def deploy_crontab?(instance_roles, cronjob_role)
+  return true if cronjob_role.nil?
+  return true if instance_roles.include?(cronjob_role)
+  Chef::Log.info('Instance is not in a cronjob role, skippings cronjob installs')
+  false
 end

--- a/easybib/providers/deploy.rb
+++ b/easybib/providers/deploy.rb
@@ -1,11 +1,8 @@
 action :deploy do
   app = new_resource.app
   deploy_data = new_resource.deploy_data
-  cronjob_role = new_resource.cronjob_role
   instance_roles = new_resource.instance_roles
   supervisor_role = new_resource.supervisor_role
-
-  cronjob_role = node['easybib_deploy']['cronjob_role'] if cronjob_role.nil?
   instance_roles = ::EasyBib.get_instance_roles(node) if instance_roles.empty?
 
   application_root_dir = "#{deploy_data['deploy_to']}/current"
@@ -32,10 +29,9 @@ action :deploy do
   # will fail otherwise.
   easybib_envconfig app
 
-  easybib_crontab "#{app}_#{new_resource.cronjob_role}" do
+  easybib_crontab app do
     crontab_file "#{application_root_dir}/deploy/crontab"
     app app
-    cronjob_role cronjob_role
     instance_roles instance_roles
   end
 

--- a/easybib/resources/crontab.rb
+++ b/easybib/resources/crontab.rb
@@ -5,5 +5,4 @@ default_action :create
 attribute :app, :default => ''
 attribute :crontab_file, :kind_of => String, :default => ''
 attribute :instance_roles, :default => []
-attribute :cronjob_role, :kind_of => String, :default => nil
 attribute :crontab_user, :kind_of => String, :default => 'www-data'

--- a/easybib/resources/deploy.rb
+++ b/easybib/resources/deploy.rb
@@ -4,6 +4,5 @@ default_action :deploy
 
 attribute :app, :default => {}
 attribute :deploy_data, :default => {}
-attribute :cronjob_role, :kind_of => String, :default => nil
 attribute :supervisor_role, :kind_of => String, :default => nil
 attribute :instance_roles, :default => []

--- a/easybib/tests/test_crontab_provider.rb
+++ b/easybib/tests/test_crontab_provider.rb
@@ -1,0 +1,32 @@
+require 'test/unit'
+require 'chef'
+
+# "Hack" to be able to load a provider without failing on the action keyword
+# I use this to test the function spec'ed below
+def self.action(_unused)
+end
+
+require File.join(File.dirname(__FILE__), '../providers', 'crontab.rb')
+
+class TestEasyBibCrontabProvider < Test::Unit::TestCase
+  def test_deploy_crontab
+    assert_equal(
+      deploy_crontab?([], nil),
+      true
+    )
+  end
+
+  def test_deploy_crontab_wrong_role
+    assert_equal(
+      deploy_crontab?(%w(role1 role2), 'housekeeping'),
+      false
+    )
+  end
+
+  def test_deploy_crontab_all_roles
+    assert_equal(
+      deploy_crontab?(%w(role1 housekeeping), 'housekeeping'),
+      true
+    )
+  end
+end

--- a/easybib/tests/test_deploy.rb
+++ b/easybib/tests/test_deploy.rb
@@ -2,8 +2,6 @@ require 'test/unit'
 require 'chef'
 require File.join(File.dirname(__FILE__), '../libraries', 'easybib.rb')
 require File.join(File.dirname(__FILE__), '../libraries', 'deploy.rb')
-
-# rubocop:disable ClassLength
 class TestEasyBibDeploy < Test::Unit::TestCase
   include EasyBib::Deploy
 
@@ -119,27 +117,6 @@ class TestEasyBibDeploy < Test::Unit::TestCase
     assert_equal(
       false,
       allow_deploy('app', 'app', %w(some-layer some-different-layer), fake_node)
-    )
-  end
-
-  def test_deploy_crontab
-    assert_equal(
-      deploy_crontab?([], nil),
-      true
-    )
-  end
-
-  def test_deploy_crontab_wrong_role
-    assert_equal(
-      deploy_crontab?(%w(role1 role2), 'housekeeping'),
-      false
-    )
-  end
-
-  def test_deploy_crontab_all_roles
-    assert_equal(
-      deploy_crontab?(%w(role1 housekeeping), 'housekeeping'),
-      true
     )
   end
 end


### PR DESCRIPTION
Also relocates cronjob related functions from shared lib to cronjob provider