### PR TITLE
Cleanup: Remove redundant application parameter

### DIFF
--- a/easybib/providers/deploy.rb
+++ b/easybib/providers/deploy.rb
@@ -1,10 +1,8 @@
 action :deploy do
   app = new_resource.app
   deploy_data = new_resource.deploy_data
-  instance_roles = new_resource.instance_roles
-  supervisor_role = new_resource.supervisor_role
-  instance_roles = ::EasyBib.get_instance_roles(node) if instance_roles.empty?
 
+  instance_roles = ::EasyBib.get_instance_roles(node)
   application_root_dir = "#{deploy_data['deploy_to']}/current"
   document_root_dir = "#{application_root_dir}/#{deploy_data['document_root']}/"
 

--- a/easybib/providers/deploy_manager.rb
+++ b/easybib/providers/deploy_manager.rb
@@ -52,7 +52,6 @@ def run_deploys(deployments, app_name, app_data)
 
     easybib_deploy application do
       deploy_data deploy
-      app application
     end
 
     did_we_deploy = true

--- a/easybib/resources/deploy.rb
+++ b/easybib/resources/deploy.rb
@@ -4,5 +4,3 @@ default_action :deploy
 
 attribute :app, :kind_of => String, :name_attribute => true
 attribute :deploy_data, :default => {}
-attribute :supervisor_role, :kind_of => String, :default => nil
-attribute :instance_roles, :default => []

--- a/easybib/resources/deploy.rb
+++ b/easybib/resources/deploy.rb
@@ -2,7 +2,7 @@ actions :deploy
 
 default_action :deploy
 
-attribute :app, :default => {}
+attribute :app, :kind_of => String, :name_attribute => true
 attribute :deploy_data, :default => {}
 attribute :supervisor_role, :kind_of => String, :default => nil
 attribute :instance_roles, :default => []

--- a/stack-api/recipes/deploy-silex.rb
+++ b/stack-api/recipes/deploy-silex.rb
@@ -23,7 +23,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   easybib_nginx application do

--- a/stack-citationapi/recipes/deploy-citationapi.rb
+++ b/stack-citationapi/recipes/deploy-citationapi.rb
@@ -23,7 +23,6 @@ get_apps_to_deploy.each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   easybib_nginx application do

--- a/stack-cmbm/recipes/deploy-nginxapp.rb
+++ b/stack-cmbm/recipes/deploy-nginxapp.rb
@@ -47,7 +47,6 @@ applications.each do |app_name, app_config|
   if is_aws
     easybib_deploy app_name do
       deploy_data app_config
-      app app_name
     end
   else
     easybib_envconfig app_name

--- a/stack-easybib/recipes/deploy-easybib.rb
+++ b/stack-easybib/recipes/deploy-easybib.rb
@@ -15,7 +15,6 @@ get_apps_to_deploy.each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   # clean up old config before migration

--- a/stack-easybib/recipes/deploy-gearman-worker.rb
+++ b/stack-easybib/recipes/deploy-gearman-worker.rb
@@ -13,7 +13,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   include_recipe 'monit::pecl-manager'

--- a/stack-easybib/recipes/deploy-housekeeping.rb
+++ b/stack-easybib/recipes/deploy-housekeeping.rb
@@ -24,7 +24,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
 end

--- a/stack-easybib/recipes/deploy-silexapps.rb
+++ b/stack-easybib/recipes/deploy-silexapps.rb
@@ -13,7 +13,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   easybib_nginx application do

--- a/stack-fruitkid/recipes/deploy-easybib.rb
+++ b/stack-fruitkid/recipes/deploy-easybib.rb
@@ -23,7 +23,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   service 'php-fpm' do

--- a/stack-qa/recipes/deploy-qa.rb
+++ b/stack-qa/recipes/deploy-qa.rb
@@ -28,7 +28,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   easybib_nginx application do

--- a/stack-qa/recipes/deploy-satis.rb
+++ b/stack-qa/recipes/deploy-satis.rb
@@ -19,7 +19,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   %w(/mnt/satis-output/ /mnt/composer-tmp/).each do |dir|

--- a/stack-research/recipes/deploy-research.rb
+++ b/stack-research/recipes/deploy-research.rb
@@ -12,7 +12,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   # clean up old config before migration

--- a/stack-research/recipes/deploy-solr.rb
+++ b/stack-research/recipes/deploy-solr.rb
@@ -9,7 +9,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   execute "copy config from git to solr basedir - #{application}" do

--- a/stack-test/recipes/deploy.rb
+++ b/stack-test/recipes/deploy.rb
@@ -15,7 +15,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_deploy application do
     deploy_data deploy
-    app application
   end
 
   config_template = 'silex.conf.erb'


### PR DESCRIPTION
The application name is already passed everywhere as name anyway.

Also removes two parameters that are obsolete and nowhere in use.

ref https://github.com/easybib/ops/issues/233