### PR TITLE
Cleanups: Remove parameters we never supply anywhere

### DIFF
--- a/easybib/providers/nginx.rb
+++ b/easybib/providers/nginx.rb
@@ -27,7 +27,6 @@ action :setup do
   app_dir = get_app_dir(new_resource, node)
   config_name = get_config_name(new_resource)
   nginx_extras = get_nginx_extras(new_resource, node)
-  nginx_caching = get_nginx_caching(new_resource, node)
 
   htpasswd = get_htpasswd(new_resource, application)
 
@@ -68,7 +67,7 @@ action :setup do
       :routes_denied => routes_denied,
       :htpasswd => htpasswd,
       :listen_opts => listen_opts,
-      :nginx_caching => nginx_caching,
+      :nginx_caching => node['nginx-app']['cache'],
       :gzip => node['nginx-app']['gzip']
     )
     notifies :run, "execute[#{execute_name}]", :immediately
@@ -119,12 +118,6 @@ end
 def get_domain_name(new_resource, node)
   return new_resource.domain_name unless new_resource.domain_name.nil?
   ::EasyBib::Config.get_domains(node, new_resource.app_name)
-end
-
-# nginx caching - this does not deal with browser cache headers
-def get_nginx_caching(new_resource, node)
-  return new_resource.nginx_caching unless new_resource.nginx_caching.nil?
-  node['nginx-app']['cache']
 end
 
 def get_nginx_extras(new_resource, node)

--- a/easybib/resources/nginx.rb
+++ b/easybib/resources/nginx.rb
@@ -4,7 +4,6 @@ default_action :setup
 
 attribute :app_name, :kind_of => String, :name_attribute => true
 attribute :config_template, :kind_of => String, :required => true
-attribute :config_name, :kind_of => String, :default => ''
 attribute :doc_root, :kind_of => String, :default => 'www'
 attribute :access_log, :kind_of => String, :default => 'off'
 attribute :domain_name, :kind_of => String, :default => nil

--- a/easybib/resources/nginx.rb
+++ b/easybib/resources/nginx.rb
@@ -14,5 +14,4 @@ attribute :deploy_dir, :kind_of => String, :default => nil
 attribute :app_dir, :kind_of => String, :default => nil
 attribute :default_router, :kind_of => String, :default => nil
 attribute :listen_opts, :kind_of => String, :default => nil
-attribute :nginx_caching, :kind_of => Hash, :default => nil
 attribute :cookbook, :kind_of => String, :default => 'nginx-app'


### PR DESCRIPTION
* We never supply a different `config_name` anywhere, so we always fall back to application name anyway
* nginx caching is always configured using stack json attributes, never as a parameter

https://github.com/easybib/ops/issues/233