### PR TITLE
Cleaning up easybib_crontab

### DIFF
--- a/easybib/README.md
+++ b/easybib/README.md
@@ -80,6 +80,3 @@ For example, this stack json:
  }
  ```
 
- ## attributes
-
-  * `crontab_user`: the user to clear the crontab for

--- a/easybib/attributes/default.rb
+++ b/easybib/attributes/default.rb
@@ -3,7 +3,6 @@ default['easybib_deploy']['provide_pear']  = false
 default['easybib_deploy']['cron_path']     = '/usr/local/bin:/usr/bin:/bin'
 default['easybib_deploy']['envtype']       = 'playground'
 default['easybib_deploy']['cronjob_role']  = nil
-default['easybib_deploy']['cronjob_user']  = 'www-data'
 default['easybib_deploy']['supervisor_role'] = 'consumer'
 default['easybib']['enable_ppa_mirror']  = false
 default['easybib']['php_mirror_version'] = '55'

--- a/easybib/providers/crontab.rb
+++ b/easybib/providers/crontab.rb
@@ -69,13 +69,12 @@ end
 
 action :delete do
   app = new_resource.app
-  crontab_user = new_resource.crontab_user
 
   execute 'Clear old crontab' do
-    user crontab_user
+    user node['nginx-app']['user']
     # crontab will exit with 130 if crontab has already been cleared
     # adding a "; true" to remove the loooong warning in chef logs everyone stumbles upon
-    command "crontab -u #{crontab_user} -r; true"
+    command "crontab -u #{node['nginx-app']['user']} -r; true"
     ignore_failure true
   end
 

--- a/easybib/providers/deploy.rb
+++ b/easybib/providers/deploy.rb
@@ -29,7 +29,6 @@ action :deploy do
 
   easybib_crontab app do
     crontab_file "#{application_root_dir}/deploy/crontab"
-    app app
     instance_roles instance_roles
   end
 

--- a/easybib/resources/crontab.rb
+++ b/easybib/resources/crontab.rb
@@ -5,4 +5,3 @@ default_action :create
 attribute :app, :default => ''
 attribute :crontab_file, :kind_of => String, :default => ''
 attribute :instance_roles, :default => []
-attribute :crontab_user, :kind_of => String, :default => 'www-data'

--- a/easybib/resources/crontab.rb
+++ b/easybib/resources/crontab.rb
@@ -2,6 +2,6 @@ actions :create, :delete
 
 default_action :create
 
-attribute :app, :default => ''
+attribute :app, :default => '', :kind_of => String, :name_attribute => true
 attribute :crontab_file, :kind_of => String, :default => ''
 attribute :instance_roles, :default => []

--- a/ies/recipes/role-undeploy.rb
+++ b/ies/recipes/role-undeploy.rb
@@ -6,7 +6,6 @@ node['deploy'].each do |application, deploy|
 
   easybib_crontab application do
     app application
-    crontab_user node['easybib_deploy']['crontab_user']
     action :delete
   end
 

--- a/ies/recipes/role-undeploy.rb
+++ b/ies/recipes/role-undeploy.rb
@@ -5,7 +5,6 @@ node['deploy'].each do |application, deploy|
   application_root_dir = "#{deploy_data['deploy_to']}/current"
 
   easybib_crontab application do
-    app application
     action :delete
   end
 


### PR DESCRIPTION
Removing redundant parameter, removed broken cronjob user parameter

The cronjob user parameter was entirely messed, and the parameter is actually only used in the `delete` action.  During creation, `node['nginx-app']['user']` is used as the user parameter in the code, so I standardized to that one.

https://github.com/easybib/ops/issues/233