### PR TITLE
Deploy rds-test script to nginxapp instances

### DIFF
--- a/stack-easybib/files/default/rds-test.sh
+++ b/stack-easybib/files/default/rds-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Script: rds-test
+# Description: Iteratively curl the rds-test.php script and log the output.
+# Author: Brian Wiborg <b.wiborg@chegg.com>
+#
+# Usage: rds-test [<seconds>] [<hostname>] [<logfile>]
+#
+# Arguments:
+# - seconds     - Exit in n seconds (default: 60)
+# - hostname    - The HTTP header host (default: rds.test)
+# - logfile     - Which file to log to (default: /var/log/rds.log)
+
+seconds="${1:-60}"
+hostname="${2:-rds.test}"
+logfile="${3:-/var/log/rds.log}"
+num_lines=0
+
+function log() {
+	timestamp="$(date +%Y-%m-%d_%H:%M:%S.%N)"
+	echo $timestamp $@ >> "$logfile"
+	echo $timestamp $@
+}
+
+function kill() {
+    log "interrupted. (Seconds: $SECONDS, Requests: $num_lines, Logfile: $logfile)"
+    exit 1
+}
+
+log "starting! (Seconds: $seconds, Host: $hostname, Logfile: $logfile)"
+trap kill INT TERM
+sleep 2
+
+while true; do
+    if (( SECONDS >= seconds )); then
+        log "done. (Seconds: ${SECONDS}, Requests: $num_lines, Logfile: $logfile)"
+        exit 0
+    fi
+
+    log $(curl -H "Host: $hostname" localhost/rds-test.php 2>/dev/null)
+    ((num_lines++))
+done
+

--- a/stack-easybib/recipes/deploy-rdstest.rb
+++ b/stack-easybib/recipes/deploy-rdstest.rb
@@ -1,0 +1,25 @@
+get_apps_to_deploy.each do |application, deploy|
+  case application
+  when 'rds_test'
+    unless allow_deploy(application, 'rds_test', %w(nginxphpapp))
+      Chef::Log.info("stack-easybib::deploy-rdstest - #{application} skipped")
+      next
+    end
+  else
+    Chef::Log.info("stack-easybib::deploy-rdstest - #{application} skipped")
+    next
+  end
+
+  Chef::Log.info("stack-easybib::deploy-rdstest - Deployment started as #{deploy[:user]}:#{deploy[:group]}")
+
+  easybib_deploy application do
+    deploy_data deploy
+  end
+
+  cron_d 'rds_test' do
+    command 'cd /srv/www/rds_test/current; php rds-test.php 2>&1 | logger -t rds_test'
+    hour '*'
+    minute '*'
+    path '/usr/local/bin:/usr/bin'
+  end
+end

--- a/stack-easybib/recipes/deploy-rdstest.rb
+++ b/stack-easybib/recipes/deploy-rdstest.rb
@@ -22,4 +22,11 @@ get_apps_to_deploy.each do |application, deploy|
     notifies :reload, 'service[nginx]', :delayed
     notifies node['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
+
+  cookbook_file '/usr/local/bin/rds-test' do
+    source 'rds-test.sh'
+    user 'root'
+    group 'root'
+    mode '0770'
+  end
 end

--- a/stack-easybib/recipes/deploy-rdstest.rb
+++ b/stack-easybib/recipes/deploy-rdstest.rb
@@ -16,10 +16,10 @@ get_apps_to_deploy.each do |application, deploy|
     deploy_data deploy
   end
 
-  cron_d 'rds_test' do
-    command 'cd /srv/www/rds_test/current; php rds-test.php 2>&1 | logger -t rds_test'
-    hour '*'
-    minute '*'
-    path '/usr/local/bin:/usr/bin'
+  easybib_nginx application do
+    cookbook 'stack-easybib'
+    config_template 'silex.conf.erb'
+    notifies :reload, 'service[nginx]', :delayed
+    notifies node['php-fpm']['restart-action'], 'service[php-fpm]', :delayed
   end
 end

--- a/stack-easybib/recipes/role-nginxphpapp.rb
+++ b/stack-easybib/recipes/role-nginxphpapp.rb
@@ -4,7 +4,6 @@ include_recipe 'php::module-gearman'
 
 if is_aws
   include_recipe 'stack-easybib::deploy-easybib'
-  include_recipe 'stack-easybib::deploy-rdstest'
   include_recipe 'stack-easybib::deploy-silexapps'
   include_recipe 'postfix::relay'
 else

--- a/stack-easybib/recipes/role-nginxphpapp.rb
+++ b/stack-easybib/recipes/role-nginxphpapp.rb
@@ -4,6 +4,7 @@ include_recipe 'php::module-gearman'
 
 if is_aws
   include_recipe 'stack-easybib::deploy-easybib'
+  include_recipe 'stack-easybib::deploy-rdstest'
   include_recipe 'stack-easybib::deploy-silexapps'
   include_recipe 'postfix::relay'
 else


### PR DESCRIPTION
# Changes

As of this PR we deploy a PHP script for testing RDS connection round-trips to every nginxapp instance in stack-easybib. The script is deployed in form of an AWS OpsWorks app and comes with a small shell script that iteratively curl's localhost and writes the response to a log-file.

# CR

 - please update the stable PR post-merge

Related: easybib/ops#226

