### PR TITLE
Fix: default and name-attribute dont work together

### DIFF
--- a/easybib/resources/crontab.rb
+++ b/easybib/resources/crontab.rb
@@ -2,6 +2,6 @@ actions :create, :delete
 
 default_action :create
 
-attribute :app, :default => '', :kind_of => String, :name_attribute => true
+attribute :app, :kind_of => String, :name_attribute => true
 attribute :crontab_file, :kind_of => String, :default => ''
 attribute :instance_roles, :default => []


### PR DESCRIPTION
Currently the app name for cronjobs is always empty, since the default always overrides the name attribute.