### PR TITLE
Render all LetsEncrypt rewrites into a single vHost

### DIFF
--- a/stack-qa/templates/default/redirect-certbot.conf.erb
+++ b/stack-qa/templates/default/redirect-certbot.conf.erb
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+
+    server_name <%= @domains.keys.join(' ')%>;
+
+<% unless @certbot_port.nil? -%>
+    # proxy to certbot-auto (when it's running)
+    location /.well-known/acme-challenge {
+        proxy_pass http://127.0.0.1:<%=@certbot_port%>;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+<% end -%>
+}

--- a/stack-qa/templates/default/redirect-ssl.conf.erb
+++ b/stack-qa/templates/default/redirect-ssl.conf.erb
@@ -1,22 +1,16 @@
 server {
-    listen 80;
     listen 443 default_server ssl;
 
-<% unless @certbot_port.nil? -%>
-    # proxy to certbot-auto (when it's running)
-    location /.well-known/acme-challenge {
-        proxy_pass http://127.0.0.1:<%=@certbot_port%>;
-    }
-
-<% end -%>
     ssl                       on;
     ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
     ssl_certificate           <%=@ssl_dir%>/cert.combined.pem;
-    ssl_certificate_key       <%=@ssl_dir%>/cert.key;
+    ssl_certificate_key       <%=@ssl_dir%>/cert.combined.pem;
     ssl_ciphers               HIGH:!RC4:!eNULL:!aNULL:!MD5@STRENGTH;
     ssl_prefer_server_ciphers on;
-    server_name <%=@domain_name%>;
-<% unless @new_domain_name.nil? -%>
-    rewrite ^ <%=@new_domain_name%> permanent;
+
+    server_name <%= @domains.keys.join(' ')%>;
+
+<% @domains.each do |domain, target| -%>
+    if ($host = "<%= domain %>") { rewrite ^ <%= target %> last; }
 <% end -%>
 }


### PR DESCRIPTION
# Changes

This PR fixes the broken redirector setup described in easybib/ops#242.

The problem was, that several vHost configuration files where rendered to disk, all containing a `default_server` directive, which validates Nginx configuration syntax.

This PR renders a single vHost configuration file to disk and then redirects based on `$host`.

It is commonly known that if-statements in Nginx configuration are evil. This is true! However, rewrites are an exception to the rule. See: https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/

# CR

 - Specs are included in the change.
 - please update the stable PR post-merge

Related: easybib/ops#242

