### PR TITLE
Remove opsworks_deploy_dir - this is unneeded

### DIFF
--- a/stack-qa/recipes/deploy-qa.rb
+++ b/stack-qa/recipes/deploy-qa.rb
@@ -20,12 +20,6 @@ node['deploy'].each do |application, deploy|
   Chef::Log.info("deploy::#{application} - Deployment started.")
   Chef::Log.info("deploy::#{application} - Deploying as user: #{deploy[:user]} and #{deploy[:group]}")
 
-  opsworks_deploy_dir do
-    user  deploy['user']
-    group deploy['group']
-    path  deploy['deploy_to']
-  end
-
   easybib_deploy application do
     deploy_data deploy
   end


### PR DESCRIPTION
The call is somewhat redundant, since [it is being done in easybib_deploy anyway](https://github.com/till/easybib-cookbooks/blob/master/easybib/providers/deploy.rb#L14-L18)

This way, all `opsworks_*` calls for a deploy are now entirely wrapped within `easybib_deploy`, which makes the chef12 migration easier

references https://github.com/easybib/ops/issues/233