### PR TITLE
Introduce custom foodcritic rules for Chef12 prep

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ task :foodcritic, [:cookbook] do |_t, args|
 
   if Gem::Version.new('1.9.2') <= Gem::Version.new(RUBY_VERSION.dup)
     epic_fail = %w()
-    ignore_rules = %w(FC059)
+    ignore_rules = %w(FC059 WT003)
 
     cb = if args.cookbook.nil?
            find_cookbooks('.').join(' ')
@@ -72,6 +72,7 @@ task :foodcritic, [:cookbook] do |_t, args|
     fc_command = 'bundle exec foodcritic -C -f any -P '
     fc_command << " -f #{epic_fail.join(' -f ')}" unless epic_fail.empty?
     fc_command << " -t ~#{ignore_rules.join(' -t ~')}" unless ignore_rules.empty?
+    fc_command << ' -I ./foodcritic-rules.rb'
     fc_command << " #{cb}"
     verbose(false)
     sh fc_command do |ok, res|

--- a/foodcritic-rules.rb
+++ b/foodcritic-rules.rb
@@ -1,0 +1,71 @@
+# Foodcritic Custom rules as a preparation for the Chef12 move.
+#
+# Since node[deploy], node[opsworks] and opsworks_* will be gone in Chef12,
+# we are relocating everything using this in easybib_deploy, easybib/libraries/* and the wt-data cookbook
+# so that we then have one single point for each case we have to readjust for Chef12.
+
+rule 'WT001', 'Don\'t use opsworks_ definition calls outside the easybib deploy provider' do
+  tags %w(bug wt)
+  cookbook do |path|
+    recipes  = Dir["#{path}/{#{standard_cookbook_subdirs.join(',')}}/**/*.rb"]
+    recipes += Dir["#{path}/*.rb"]
+    recipes.collect do |recipe|
+      lines = File.readlines(recipe)
+
+      lines.collect.with_index do |line, index|
+        if line.match('^( *)opsworks_') && recipe != 'easybib/providers/deploy.rb'
+          {
+            :filename => recipe,
+            :matched => recipe,
+            :line => index + 1,
+            :column => 0
+          }
+        end
+      end.compact
+    end.flatten
+  end
+end
+
+rule 'WT002', 'Don\'t use node[opsworks] outside the easybib library wrappers' do
+  tags %w(bug wt)
+  cookbook do |path|
+    recipes  = Dir["#{path}/{#{standard_cookbook_subdirs.join(',')}}/**/*.rb"]
+    recipes += Dir["#{path}/*.rb"]
+    recipes.collect do |recipe|
+      lines = File.readlines(recipe)
+
+      lines.collect.with_index do |line, index|
+        if line.match('node\[(\'|"|:*)opsworks') && !recipe.match('^easybib/libraries')
+          {
+            :filename => recipe,
+            :matched => recipe,
+            :line => index + 1,
+            :column => 0
+          }
+        end
+      end.compact
+    end.flatten
+  end
+end
+
+rule 'WT003', 'Don\'t use node[deploy] outside the easybib & wt-data library wrappers' do
+  tags %w(bug wt)
+  cookbook do |path|
+    recipes  = Dir["#{path}/{#{standard_cookbook_subdirs.join(',')}}/**/*.rb"]
+    recipes += Dir["#{path}/*.rb"]
+    recipes.collect do |recipe|
+      lines = File.readlines(recipe)
+
+      lines.collect.with_index do |line, index|
+        if line.match('node\[(\'|"|:*)deploy') && !recipe.match('^easybib/libraries') && !recipe.match('^wt-data')
+          {
+            :filename => recipe,
+            :matched => recipe,
+            :line => index + 1,
+            :column => 0
+          }
+        end
+      end.compact
+    end.flatten
+  end
+end


### PR DESCRIPTION
Since node[deploy], node[opsworks] and opsworks_* will be gone in Chef12, we are relocating everything using this in easybib_deploy, easybib/libraries/* and the wt-data cookbook so that we then have one single point for each case we have to readjust for Chef12.

WT003, the disabling of `node[deploy]` is disabled currently, this need some more changes in the cookbooks.

Related: https://github.com/easybib/ops/issues/233