### PR TITLE
Fix: set an explicit version for tideways packages

### DIFF
--- a/tideways/attributes/default.rb
+++ b/tideways/attributes/default.rb
@@ -1,5 +1,6 @@
 default['tideways'] = {
   'key' => 'EEB5E8F4.asc',
   'keyserver' => nil,
-  'repository' => 'http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages'
+  'repository' => 'http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages',
+  'version' => '4.0.6'
 }

--- a/tideways/attributes/default.rb
+++ b/tideways/attributes/default.rb
@@ -2,5 +2,6 @@ default['tideways'] = {
   'key' => 'EEB5E8F4.asc',
   'keyserver' => nil,
   'repository' => 'http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages',
-  'version' => '4.0.6'
+  'php_version' => '4.0.6',
+  'daemon_version' => '1.3.9'
 }

--- a/tideways/recipes/default.rb
+++ b/tideways/recipes/default.rb
@@ -11,7 +11,8 @@ packages = ['tideways-php', 'tideways-daemon', 'tideways-cli']
 
 packages.each do |package_name|
   package package_name do
-    action :upgrade # install the latest
+    version node['tideways']['version']
+    action :install
   end
 end
 

--- a/tideways/recipes/default.rb
+++ b/tideways/recipes/default.rb
@@ -7,7 +7,11 @@ apt_repository 'tideways' do
   keyserver    node['tideways']['keyserver']
 end
 
-packages = {'tideways-php' => node['tideways']['version'], 'tideways-daemon' => nil, 'tideways-cli' => nil}
+packages = {
+  'tideways-php' => node['tideways']['php_version'],
+  'tideways-daemon' => node['tideways']['daemon_version'],
+  'tideways-cli' => nil
+}
 
 packages.each do |package_name, package_version|
 

--- a/tideways/recipes/default.rb
+++ b/tideways/recipes/default.rb
@@ -7,12 +7,18 @@ apt_repository 'tideways' do
   keyserver    node['tideways']['keyserver']
 end
 
-packages = ['tideways-php', 'tideways-daemon', 'tideways-cli']
+packages = {'tideways-php' => node['tideways']['version'], 'tideways-daemon' => nil, 'tideways-cli' => nil}
 
-packages.each do |package_name|
+packages.each do |package_name, package_version|
+
+  package_action = :upgrade
+  unless package_version.nil?
+    package_action = :install
+  end
+
   package package_name do
-    version node['tideways']['version']
-    action :install
+    version package_version
+    action package_action
   end
 end
 

--- a/tideways/recipes/default.rb
+++ b/tideways/recipes/default.rb
@@ -15,10 +15,8 @@ packages = {
 
 packages.each do |package_name, package_version|
 
-  package_action = :upgrade
-  unless package_version.nil?
-    package_action = :install
-  end
+  package_action = :install
+  package_action = :upgrade if package_version.nil?
 
   package package_name do
     version package_version


### PR DESCRIPTION
# Changes

Ensures only certain versions are installed, so new packages don't break our setup.

# CR

 - test in `www-vagrant`
 - test on playground
 - please update the stable PR post-merge

Related: easybib/ops#251