### PR TITLE
[WIP] RDS Test additions

### DIFF
--- a/stack-easybib/recipes/deploy-rdstest.rb
+++ b/stack-easybib/recipes/deploy-rdstest.rb
@@ -1,3 +1,6 @@
+include_recipe 'php-fpm::service'
+include_recipe 'nginx-app::service'
+
 get_apps_to_deploy.each do |application, deploy|
   case application
   when 'rds_test'


### PR DESCRIPTION
# Changes

The `deploy-rdstest` recipe lacks a few dependencies. These where available by incident in earlier tests, probably because other apps have been installed on the instance that pulled those dependencies in.

# CR

 - please update the stable PR post-merge

Related: easybib/ops#226

