### PR TITLE
Add missing php modules and tests

### DIFF
--- a/stack-api/recipes/role-nginxphpapp.rb
+++ b/stack-api/recipes/role-nginxphpapp.rb
@@ -12,16 +12,32 @@ if node['easybib']['cluster_name'] == 'API Staging'
   node.normal['php-apc']['package_prefix'] = 'php'
 
   php_core_deps = %W(
-    php#{php_version}-fpm
-    php#{php_version}-cli
-    php#{php_version}-mbstring
-    php#{php_version}-mysql
-    php#{php_version}-curl
+    php#{php_version}-apcu
     php#{php_version}-bcmath
+    php#{php_version}-cli
+    php#{php_version}-ctype
+    php#{php_version}-curl
     php#{php_version}-dom
+    php#{php_version}-fileinfo
+    php#{php_version}-fpm
+    php#{php_version}-iconv
+    php#{php_version}-intl
+    php#{php_version}-json
+    php#{php_version}-mbstring
+    php#{php_version}-memcache
+    php#{php_version}-pdo-mysql
+    php#{php_version}-pdo-pgsql
+    php#{php_version}-phar
+    php#{php_version}-simplexml
     php#{php_version}-soap
+    php#{php_version}-sockets
+    php#{php_version}-tidy
+    php#{php_version}-tokenizer
+    php#{php_version}-xml
+    php#{php_version}-xmlreader
+    php#{php_version}-xmlwriter
+    php#{php_version}-opcache
     php#{php_version}-zip
-    php-memcache
   )
 
   node.normal['php-fpm'] = {

--- a/stack-api/spec/role-nginxphpapp_spec.rb
+++ b/stack-api/spec/role-nginxphpapp_spec.rb
@@ -1,9 +1,40 @@
 require_relative 'spec_helper'
 
 describe 'stack-api::role-nginxphpapp' do
-  let(:runner)       { ChefSpec::Runner.new }
+  let(:runner)       { ChefSpec::Runner.new(:step_into => ['php-fpm']).converge('ies::role-phpapp') }
   let(:chef_run)     { runner.converge(described_recipe) }
   let(:node)         { runner.node }
+  let(:php_version)  { '5.6' }
+  let(:php_deps)     do
+    %W(
+      php#{php_version}-apcu
+      php#{php_version}-bcmath
+      php#{php_version}-cli
+      php#{php_version}-ctype
+      php#{php_version}-curl
+      php#{php_version}-dom
+      php#{php_version}-fileinfo
+      php#{php_version}-fpm
+      php#{php_version}-iconv
+      php#{php_version}-intl
+      php#{php_version}-json
+      php#{php_version}-mbstring
+      php#{php_version}-memcache
+      php#{php_version}-pdo-mysql
+      php#{php_version}-pdo-pgsql
+      php#{php_version}-phar
+      php#{php_version}-simplexml
+      php#{php_version}-soap
+      php#{php_version}-sockets
+      php#{php_version}-tidy
+      php#{php_version}-tokenizer
+      php#{php_version}-xml
+      php#{php_version}-xmlreader
+      php#{php_version}-xmlwriter
+      php#{php_version}-opcache
+      php#{php_version}-zip
+    ).join(',')
+  end
 
   before do
     node.override['opsworks']['stack']['name'] = 'Stack'
@@ -14,6 +45,7 @@ describe 'stack-api::role-nginxphpapp' do
       :deploy_to => '/srv/www/silex',
       :document_root => 'public'
     }
+    node.override['php-fpm']['packages'] = php_deps
   end
 
   it 'pulls in ies::role-phpapp' do
@@ -22,5 +54,11 @@ describe 'stack-api::role-nginxphpapp' do
 
   it 'deploys silex' do
     expect(chef_run).to include_recipe('stack-api::deploy-silex')
+  end
+
+  it 'installs all php-module deps' do
+    php_deps.split(',').each do |dep|
+      expect(chef_run).to install_package(dep)
+    end
   end
 end


### PR DESCRIPTION
# Changes

This PR runs the `install_package` matcher against every PHP module we have installed in production.

It also completes the list of missing PHP modules in the recipe.

# CR

- `bundle exec appraisal rake 'spec[stack-api]'`
 - please update the stable PR post-merge

Related: easybib/ops#259
