### PR TITLE
[WIP] Delete the PHP sessionclean cronjob

### DIFF
--- a/php-fpm/recipes/default.rb
+++ b/php-fpm/recipes/default.rb
@@ -79,3 +79,10 @@ bins.each do |php_bin|
 end
 
 include_recipe 'php-fpm::cloudwatch' if is_aws
+
+# PHP by default installs a sessioncleanup cron-job, which
+# a) we do not need, since all our session are stored in memcache
+# b) causes a PHP warning on all instances to be sent out to sysops@ due to currently missing tideways.so for php-7.1
+file '/etc/cron.d/php' do
+  action :delete
+end

--- a/php-fpm/spec/default_spec.rb
+++ b/php-fpm/spec/default_spec.rb
@@ -46,6 +46,10 @@ describe 'php-fpm::default' do
     end
   end
 
+  it 'removes the php session-cleanup cron-job' do
+    expect(chef_run).to delete_file('/etc/cron.d/php')
+  end
+
   # it "creates symlinks to all the binaries" do
   #  Mixlib::ShellOut.stub(:new).and_return(@shellout)
   #  ["pear", "peardev", "pecl", "phar", "phar.phar", "php-config", "phpize"].each do |bin|


### PR DESCRIPTION
# Changes

PHP by default installs a session-cleanup cron-job which is triggering a PHP warning to be sent out to sysops@ every 30mins. We do not need this cron-job because all our sessions are stored in memcache.

With this PR the cron-job will be deleted automatically upon installation of `php-fpm`.

# CR

- RSpecs included
 - please update the stable PR post-merge

Related: easybib/ops#272
