### PR TITLE
Gearman PPA has changed

### DIFF
--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -20,7 +20,7 @@ execute 'systemctl daemon-reload' do
   end
 end
 
-cookbook_file "/etc/init/#{name}.conf" do
+cookbook_file "/etc/init/#{name}.override" do
   source 'upstart.conf'
   owner 'root'
   group 'root'

--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -20,7 +20,7 @@ execute 'systemctl daemon-reload' do
   end
 end
 
-cookbook_file "/etc/init/#{name}.override" do
+cookbook_file "/etc/init/#{name}.conf" do
   source 'upstart.conf'
   owner 'root'
   group 'root'

--- a/php/attributes/default.rb
+++ b/php/attributes/default.rb
@@ -17,6 +17,8 @@ default['php-apc']['load_priority'] = nil
 
 default['php-gearman'] = {}
 default['php-gearman']['package_prefix'] = nil
+default['php-gearman']['package_uri'] = 'ppa:ondrej/pkg-gearman'
+default['php-gearman']['package_distro'] = 'trusty'
 
 default['php-mysqli']['settings']['reconnect'] = 1
 default['php-mysqli']['load_priority'] = nil

--- a/php/recipes/module-gearman.rb
+++ b/php/recipes/module-gearman.rb
@@ -1,5 +1,10 @@
 include_recipe 'php::dependencies-ppa'
 
+apt_repository 'pkg-gearman' do
+  uri          node['php-gearman']['package_uri']
+  distribution node['php-gearman']['package_distro']
+end
+
 php_ppa_package 'gearman' do
   package_prefix node['php-gearman']['package_prefix']
 end


### PR DESCRIPTION

# Changes

Added New PPA to php:module-gearman per https://www.patreon.com/posts/gearman-now-in-14627464

This solved the gearmand8 issue with package installation.

however this caused a problem with the gearman-job-server restart... I think because /etc/init/gearman-job-server.conf was missing and only override existed?  

I am not sure if this is the proper fix.  or if conf and override should both exist?

# CR

Related: OPS-14646
