### PR TITLE
Add gearman conf if missing

### DIFF
--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -20,6 +20,14 @@ execute 'systemctl daemon-reload' do
   end
 end
 
+cookbook_file "/etc/init/#{name}.conf" do
+  action :create_if_missing
+  source 'upstart.conf'
+  owner 'root'
+  group 'root'
+  mode 00644
+end
+
 cookbook_file "/etc/init/#{name}.override" do
   source 'upstart.conf'
   owner 'root'


### PR DESCRIPTION
# Changes

creates /etc/init/gearmand.conf if missing 

# CR

 - _(if applicable) how to test them_
 - please update the stable PR post-merge

Related: #issue
