### PR TITLE
OPS-15607. Removed Conf file because it is provided by package and co…

### DIFF
--- a/ies-gearmand/recipes/service.rb
+++ b/ies-gearmand/recipes/service.rb
@@ -20,14 +20,6 @@ execute 'systemctl daemon-reload' do
   end
 end
 
-cookbook_file "/etc/init/#{name}.conf" do
-  action :create_if_missing
-  source 'upstart.conf'
-  owner 'root'
-  group 'root'
-  mode 00644
-end
-
 cookbook_file "/etc/init/#{name}.override" do
   source 'upstart.conf'
   owner 'root'


### PR DESCRIPTION
Removed Conf file
----
Processing triggers for ureadahead (0.100.0-16) ...
STDERR: Configuration file '/etc/init/gearman-job-server.conf'
==> File on system created by you or by a script.
==> File also in package provided by package maintainer.
What would you like to do about it ?  Your options are:
Y or I  : install the package maintainer's version
N or O  : keep your currently-installed version
D     : show the differences between the versions
Z     : start a shell to examine the situation
The default action is to keep your current version.
*** gearman-job-server.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package gearman-job-server (--configure):
EOF on stdin at conffile prompt
Errors were encountered while processing:
gearman-job-server
E: Sub-process /usr/bin/dpkg returned an error code (1)
---- End output of apt-get -q -y install gearman-job-server=1.0.6-3 ----
Ran apt-get -q -y install gearman-job-server=1.0.6-3 returned 100