### PR TITLE
Support for force set-path for forwarding_layer configuration

### DIFF
--- a/haproxy/spec/backend_forwarding-http-set-path_spec.rb
+++ b/haproxy/spec/backend_forwarding-http-set-path_spec.rb
@@ -19,6 +19,7 @@ describe 'haproxy::configure' do
               :url => '/url',
               :host => 'app2.tld'
             },
+            :http_set_path => '/some-random-path/here.html',
             :servers => {
               'second-app-www1' => 'second.app1.tld',
               'second-app-www2' => 'second.app2.tld'
@@ -33,12 +34,12 @@ describe 'haproxy::configure' do
   let(:chef_run) { runner.converge('haproxy::configure') }
   let(:node) { runner.node }
 
-  describe 'forward servers set - check settings' do
+  describe 'forward servers with set path - check settings' do
     before do
       stub_command('pgrep haproxy').and_return(false)
     end
 
-    it 'Configures haproxy' do
+    it 'Configures haproxy with http-request set-path when defined' do
 
       expect(chef_run).to create_template('/etc/haproxy/haproxy.cfg').with(
         :user => 'root',
@@ -47,30 +48,9 @@ describe 'haproxy::configure' do
       )
 
       expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
-        'backend app2_forward'
+        'http-request set-path /some-random-path/here.html'
       )
 
-      expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
-        'server second-app-www1 second.app1.tld:80'
-      )
-
-      expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
-        'server second-app-www2 second.app2.tld:80'
-      )
-
-    end
-
-    it 'Configures haproxy without http-request set-path when not defined' do
-
-      expect(chef_run).to create_template('/etc/haproxy/haproxy.cfg').with(
-        :user => 'root',
-        :group => 'root',
-        :mode => 0644
-      )
-
-      expect(chef_run).not_to render_file('/etc/haproxy/haproxy.cfg').with_content(
-        'http-request set-path'
-      )
     end
   end
 end

--- a/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
@@ -21,6 +21,9 @@ end
 
 backend <%= @layername %>_forward
   balance roundrobin
+  <%if !@http_set_path.nil? -%>
+  http-request set-path <%= @http_set_path %>
+  <% end -%>
   option httpchk <%= health_check_string %>
   <% @servers.each do |name,host| -%>
   server <%= name %> <%= host %>:80 weight 10 maxconn <%= haproxy_maxconn %> rise <%= haproxy_rise %> fall <%= haproxy_fall %> check inter <%= haproxy_check_interval %>

--- a/haproxy/templates/default/haproxy.easybib.cfg.erb
+++ b/haproxy/templates/default/haproxy.easybib.cfg.erb
@@ -37,6 +37,7 @@ if !node['haproxy']['forwarding_layers'].nil?
   <%= render "haproxy.cfg.forwardingbackend.erb", :variables => {
       'layername' => layername,
       'health_check' => layerconfig['health_check'],
+      'http_set_path' => layerconfig['http_set_path'],
       'servers' => layerconfig['servers'],
       'node' => @node
   } %>


### PR DESCRIPTION

# Changes

- Support for `http-request set-path` in the backend definition for forwarding_layers configuration (new attribute is `http_set_path`)
- modify spec test for existance of `http_set_path` and proper backend definition
- modify spec test for NOT existance of `http_set_path`

# CR

 - _(if applicable) how to test them_
 - please update the stable PR post-merge

Related: https://github.com/easybib/sbm-issues/issues/2182
