### PR TITLE
Fixes for s3

### DIFF
--- a/haproxy/spec/backend_forwarding-http-set-path_spec.rb
+++ b/haproxy/spec/backend_forwarding-http-set-path_spec.rb
@@ -20,6 +20,7 @@ describe 'haproxy::configure' do
               :host => 'app2.tld'
             },
             :http_set_path => '/some-random-path/here.html',
+            :http_set_host => 'second.host.tld',
             :servers => {
               'second-app-www1' => 'second.app1.tld',
               'second-app-www2' => 'second.app2.tld'
@@ -49,6 +50,13 @@ describe 'haproxy::configure' do
 
       expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
         'http-request set-path /some-random-path/here.html'
+      )
+
+    end
+    it 'Configures haproxy with http-request set-header Host' do
+
+      expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
+        'http-request set-header second.host.tld'
       )
 
     end

--- a/haproxy/spec/backend_forwarding-http-set-path_spec.rb
+++ b/haproxy/spec/backend_forwarding-http-set-path_spec.rb
@@ -19,8 +19,10 @@ describe 'haproxy::configure' do
               :url => '/url',
               :host => 'app2.tld'
             },
+            :http_match_path => '/some-random-path/there.html',
             :http_set_path => '/some-random-path/here.html',
-            :http_set_host => 'second.host.tld',
+            :http_set_host => 'set.host.tld',
+            :haproxy_check_interval => '60000',
             :servers => {
               'second-app-www1' => 'second.app1.tld',
               'second-app-www2' => 'second.app2.tld'
@@ -49,14 +51,21 @@ describe 'haproxy::configure' do
       )
 
       expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
-        'http-request set-path /some-random-path/here.html'
+        'reqirep ^([^\ ]*)\ /some-random-path/there.html\ (.*)$ \1\ /some-random-path/here.html\ \2'
       )
 
     end
     it 'Configures haproxy with http-request set-header Host' do
 
       expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
-        'http-request set-header second.host.tld'
+        'http-request set-header Host set.host.tld'
+      )
+
+    end
+    it 'Configures haproxy with custom interval' do
+
+      expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
+        'server second-app-www1 second.app1.tld:80 weight 10 maxconn 255 rise 2 fall 3 check inter 60000'
       )
 
     end

--- a/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
@@ -6,7 +6,7 @@ haproxy_rise = 2
 haproxy_fall = 3
 
 # in milliseconds - 10 seconds is too slow
-haproxy_check_interval = 3000
+haproxy_check_interval_set = haproxy_check_interval || 3000
 
 # max connections
 haproxy_maxconn = 255
@@ -21,9 +21,11 @@ end
 
 backend <%= @layername %>_forward
   balance roundrobin
-  <%if !@http_set_path.nil? -%>
-  http-request set-header Host <%= host %>
+  <%if !@http_set_host.nil? -%>
+  http-request set-header Host <%= http_set_host %>
   http-request del-header Authorization
+  <% end -%>
+  <%if !@http_set_path.nil? -%>
   # this is for 1.5
   reqirep ^([^\ ]*)\ <%= @http_match_path %>\ (.*)$ \1\ <%= @http_set_path %>\ \2
   # this is for 1.6 and above: http-request set-path <%= @http_set_path %>

--- a/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
@@ -6,7 +6,10 @@ haproxy_rise = 2
 haproxy_fall = 3
 
 # in milliseconds - 10 seconds is too slow
-haproxy_check_interval_set = haproxy_check_interval || 3000
+haproxy_check_interval_set = 3000
+if !@haproxy_check_interval.nil?
+  haproxy_check_interval_set = @haproxy_check_interval
+end
 
 # max connections
 haproxy_maxconn = 255
@@ -22,16 +25,16 @@ end
 backend <%= @layername %>_forward
   balance roundrobin
   <%if !@http_set_host.nil? -%>
-  http-request set-header Host <%= http_set_host %>
+  http-request set-header Host <%= @http_set_host %>
   http-request del-header Authorization
   <% end -%>
-  <%if !@http_set_path.nil? -%>
+  <%if !@http_set_path.nil? && !@http_match_path.nil? -%>
   # this is for 1.5
   reqirep ^([^\ ]*)\ <%= @http_match_path %>\ (.*)$ \1\ <%= @http_set_path %>\ \2
   # this is for 1.6 and above: http-request set-path <%= @http_set_path %>
   <% end -%>
   option httpchk <%= health_check_string %>
   <% @servers.each do |name,host| -%>
-  server <%= name %> <%= host %>:80 weight 10 maxconn <%= haproxy_maxconn %> rise <%= haproxy_rise %> fall <%= haproxy_fall %> check inter <%= haproxy_check_interval %>
+  server <%= name %> <%= host %>:80 weight 10 maxconn <%= haproxy_maxconn %> rise <%= haproxy_rise %> fall <%= haproxy_fall %> check inter <%= haproxy_check_interval_set %>
 <% end -%>
 

--- a/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
+++ b/haproxy/templates/default/haproxy.cfg.forwardingbackend.erb
@@ -22,11 +22,14 @@ end
 backend <%= @layername %>_forward
   balance roundrobin
   <%if !@http_set_path.nil? -%>
+  http-request set-header Host <%= host %>
+  http-request del-header Authorization
   # this is for 1.5
-  reqirep  ^([^\ :]*)\ /(.*) \1\ <%= @http_set_path %>\2
+  reqirep ^([^\ ]*)\ <%= @http_match_path %>\ (.*)$ \1\ <%= @http_set_path %>\ \2
   # this is for 1.6 and above: http-request set-path <%= @http_set_path %>
   <% end -%>
   option httpchk <%= health_check_string %>
   <% @servers.each do |name,host| -%>
   server <%= name %> <%= host %>:80 weight 10 maxconn <%= haproxy_maxconn %> rise <%= haproxy_rise %> fall <%= haproxy_fall %> check inter <%= haproxy_check_interval %>
 <% end -%>
+

--- a/haproxy/templates/default/haproxy.easybib.cfg.erb
+++ b/haproxy/templates/default/haproxy.easybib.cfg.erb
@@ -37,8 +37,9 @@ if !node['haproxy']['forwarding_layers'].nil?
   <%= render "haproxy.cfg.forwardingbackend.erb", :variables => {
       'layername' => layername,
       'health_check' => layerconfig['health_check'],
-      'http_set_path' => layerconfig['http_set_path'],
       'http_set_host' => layerconfig['http_set_host'],
+      'http_set_path' => layerconfig['http_set_path'],
+      'http_match_path' => layerconfig['http_match_path'],
       'haproxy_check_interval' => layerconfig['haproxy_check_interval'],
       'servers' => layerconfig['servers'],
       'node' => @node

--- a/haproxy/templates/default/haproxy.easybib.cfg.erb
+++ b/haproxy/templates/default/haproxy.easybib.cfg.erb
@@ -38,6 +38,8 @@ if !node['haproxy']['forwarding_layers'].nil?
       'layername' => layername,
       'health_check' => layerconfig['health_check'],
       'http_set_path' => layerconfig['http_set_path'],
+      'http_set_host' => layerconfig['http_set_host'],
+      'haproxy_check_interval' => layerconfig['haproxy_check_interval'],
       'servers' => layerconfig['servers'],
       'node' => @node
   } %>


### PR DESCRIPTION
# Changes

Specific header changes for S3 - this should be expanded upon to be more extensible
now assuming static path match with static path replace

```
    "forwarding_layers": {
      "adstxt":{  
        "acl":{  
          "acl-10":"path_beg /ads.txt"
        },
        "http_match_path":"ads.txt",
        "http_set_path":"/adteam-adtxt/easybib.com/ads.txt",
        "http_set_host":"s3.amazonaws.com",
        "haproxy_check_interval":"10m",
        "health_check":"GET /adteam-adtxt/easybib.com/ads.txt HTTP/1.1\\r\\nHost:\\ s3.amazonaws.com",
        "servers":{  
           "s3_adteam":"s3.amazonaws.com"
        }
      },
```
becomes
```
backend adstxt_forward
  balance roundrobin
  http-request set-header Host s3.amazonaws.com
  http-request del-header Authorization
  # this is for 1.5
  reqirep ^([^\ ]*)\ /ads.txt\ (.*)$ \1\ /adteam-adtxt/easybib.com/ads.txt\ \2
  # this is for 1.6 and above: http-request set-path /adteam-adtxt/easybib.com/
  option httpchk GET /adteam-adtxt/easybib.com/ads.txt HTTP/1.1\r\nHost:\ s3.amazonaws.com
  server s3_adteam s3.amazonaws.com:80 weight 10 maxconn 255 rise 2 fall 3 check inter 60000
```
# CR

 - _(if applicable) how to test them_
 - please update the stable PR post-merge

Related: #issue
